### PR TITLE
pulled other missing runtime dependencies from rmw_connext

### DIFF
--- a/rmw_opendds_cpp/CMakeLists.txt
+++ b/rmw_opendds_cpp/CMakeLists.txt
@@ -112,7 +112,8 @@ add_library(
   src/rmw_trigger_guard_condition.cpp
   src/rmw_wait.cpp
   src/rmw_wait_set.cpp
-  src/serialization_format.cpp)
+  src/serialization_format.cpp
+  src/rmw_event.cpp)
 
 OPENDDS_TARGET_SOURCES(rmw_opendds_cpp resources/opendds_static_serialized_data.idl TAO_IDL_OPTIONS "-Sa -St")
 

--- a/rmw_opendds_cpp/src/rmw_event.cpp
+++ b/rmw_opendds_cpp/src/rmw_event.cpp
@@ -1,0 +1,44 @@
+// Copyright 2014-2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/rmw.h"
+
+#include "rmw_opendds_shared_cpp/event.hpp"
+
+#include "rmw_opendds_cpp/identifier.hpp"
+
+extern "C"
+{
+/// Take an event from the event handle.
+/**
+ * \param event_handle event object to take from
+ * \param event_info event info object to write taken data into
+ * \param taken boolean flag indicating if an event was taken or not
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_BAD_ALLOC` if memory allocation failed, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+rmw_ret_t
+rmw_take_event(
+  const rmw_event_t * event_handle,
+  void * event_info,
+  bool * taken)
+{
+  return __rmw_take_event(
+    opendds_identifier,
+    event_handle,
+    event_info,
+    taken);
+}
+}  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_init.cpp
+++ b/rmw_opendds_cpp/src/rmw_init.cpp
@@ -94,6 +94,18 @@ rmw_shutdown(rmw_context_t * context)
     context->implementation_identifier,
     opendds_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+rmw_context_fini(rmw_context_t * context)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    context,
+    context->implementation_identifier,
+    opendds_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   // context impl is explicitly supposed to be nullptr for now, see rmw_init's code
   // RCUTILS_CHECK_ARGUMENT_FOR_NULL(context->impl, RMW_RET_INVALID_ARGUMENT);
   *context = rmw_get_zero_initialized_context();

--- a/rmw_opendds_cpp/src/rmw_node.cpp
+++ b/rmw_opendds_cpp/src/rmw_node.cpp
@@ -52,6 +52,7 @@ rmw_ret_t
 rmw_node_assert_liveliness(const rmw_node_t * node)
 {
   // return assert_liveliness(opendds_identifier, node);
+  return RMW_RET_OK;
 }
 
 const rmw_guard_condition_t *

--- a/rmw_opendds_cpp/src/rmw_node.cpp
+++ b/rmw_opendds_cpp/src/rmw_node.cpp
@@ -47,11 +47,12 @@ rmw_destroy_node(rmw_node_t * node)
 {
   return destroy_node(opendds_identifier, node);
 }
-//rmw_ret_t
-//rmw_node_assert_liveliness(const rmw_node_t * node)
-//{
-//  return assert_liveliness(opendds_identifier, node);
-//}
+
+rmw_ret_t
+rmw_node_assert_liveliness(const rmw_node_t * node)
+{
+  // return assert_liveliness(opendds_identifier, node);
+}
 
 const rmw_guard_condition_t *
 rmw_node_get_graph_guard_condition(const rmw_node_t * node)

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/event.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/event.hpp
@@ -1,0 +1,43 @@
+// Copyright 2015-2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_OPENDDS_SHARED_CPP__EVENT_HPP_
+#define RMW_OPENDDS_SHARED_CPP__EVENT_HPP_
+
+// #include "ndds_include.hpp"
+
+#include "rmw/types.h"
+#include "rmw/event.h"
+
+#include "rmw_opendds_shared_cpp/visibility_control.h"
+
+/// Take an event from the event handle.
+/**
+ *
+ * \param event_handle event object to take from
+ * \param event_info event info object to write taken data into
+ * \param taken boolean flag indicating if an event was taken or not
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_BAD_ALLOC` if memory allocation failed, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_OPENDDS_SHARED_CPP_PUBLIC
+rmw_ret_t
+__rmw_take_event(
+  const char * implementation_identifier,
+  const rmw_event_t * event_handle,
+  void * event_info,
+  bool * taken);
+
+#endif  // RMW_OPENDDS_SHARED_CPP__EVENT_HPP_


### PR DESCRIPTION
I used rmw_connext as a template to remove the missing runtime dependencies. This is to help the test scripts execute properly. It's a stop gap until the actual functions can be checked against OpenDDS implementation.