### PR TITLE
required changes from rosidl_typesupport_opendds updates

### DIFF
--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -90,7 +90,7 @@ _create_type_name(
   const std::string & sep)
 {
   return
-    std::string(callbacks->message_name) +
+    std::string(callbacks->message_namespace) +
     "::" + sep + "::dds_::" + callbacks->message_name + "_";
 }
 

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -90,7 +90,7 @@ _create_type_name(
   const std::string & sep)
 {
   return
-    std::string(callbacks->package_name) +
+    std::string(callbacks->message_name) +
     "::" + sep + "::dds_::" + callbacks->message_name + "_";
 }
 


### PR DESCRIPTION
`rosidl_typesupport_opendds_cpp` is being updated ([PR #6](https://github.com/oci-labs/rosidl_typesupport_opendds/pull/6)) to more closely match to begin implementation of the new design.  This change is required for building `rmw_opendds` against the related change in `rosidl_typesupport_opendds_cpp`.