### PR TITLE
Publisher subscription clearcrash

### DIFF
--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/get_subscriber.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/get_subscriber.hpp
@@ -30,7 +30,7 @@ namespace rmw_opendds_cpp
  * \return native OpenDDS data reader handle if successful, otherwise `NULL`
  */
 RMW_OPENDDS_CPP_PUBLIC
-DDS::DataReader *
+DDS::DataReader_var
 get_data_reader(rmw_subscription_t * subscription);
 
 }  // namespace rmw_opendds_cpp

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_client_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_client_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_CPP__CONNEXT_STATIC_CLIENT_INFO_HPP_
-#define RMW_OPENDDS_CPP__CONNEXT_STATIC_CLIENT_INFO_HPP_
+#ifndef RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_
+#define RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_
 
 #include "rmw_opendds_shared_cpp/opendds_include.hpp"
 
@@ -30,4 +30,4 @@ struct OpenDDSStaticClientInfo
 };
 }  // extern "C"
 
-#endif  // RMW_OPENDDS_CPP__CONNEXT_STATIC_CLIENT_INFO_HPP_
+#endif  // RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_client_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_client_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_
-#define RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_
+#ifndef RMW_OPENDDS_CPP__OPENDDS_STATIC_CLIENT_INFO_HPP_
+#define RMW_OPENDDS_CPP__OPENDDS_STATIC_CLIENT_INFO_HPP_
 
 #include "rmw_opendds_shared_cpp/opendds_include.hpp"
 
@@ -30,4 +30,4 @@ struct OpenDDSStaticClientInfo
 };
 }  // extern "C"
 
-#endif  // RMW_OPENDDS_STATIC_CLIENT_INFO_HPP_
+#endif  // RMW_OPENDDS_CPP__OPENDDS_STATIC_CLIENT_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_
-#define RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_
+#ifndef RMW_OPENDDS_CPP__OPENDDS_STATIC_PUBLISHER_INFO_HPP_
+#define RMW_OPENDDS_CPP__OPENDDS_STATIC_PUBLISHER_INFO_HPP_
 
 #include <atomic>
 
@@ -90,4 +90,4 @@ private:
   std::atomic<std::size_t> current_count_;
 };
 
-#endif  // RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_
+#endif  // RMW_OPENDDS_CPP__OPENDDS_STATIC_PUBLISHER_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
@@ -32,6 +32,12 @@ struct OpenDDSStaticPublisherInfo
   DDS::DataWriter_var topic_writer_;
   const message_type_support_callbacks_t * callbacks_;
   rmw_gid_t publisher_gid;
+  OpenDDSStaticPublisherInfo() :
+    dds_publisher_(),
+    listener_(nullptr),
+    topic_writer_(),
+    callbacks_(nullptr),
+    publisher_gid() {}
 };
 }  // extern "C"
 

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_publisher_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_CPP__CONNEXT_STATIC_PUBLISHER_INFO_HPP_
-#define RMW_OPENDDS_CPP__CONNEXT_STATIC_PUBLISHER_INFO_HPP_
+#ifndef RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_
+#define RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_
 
 #include <atomic>
 
@@ -90,4 +90,4 @@ private:
   std::atomic<std::size_t> current_count_;
 };
 
-#endif  // RMW_OPENDDS_CPP__CONNEXT_STATIC_PUBLISHER_INFO_HPP_
+#endif  // RMW_OPENDDS_STATIC_PUBLISHER_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_CPP__CONNEXT_STATIC_SERVICE_INFO_HPP_
-#define RMW_OPENDDS_CPP__CONNEXT_STATIC_SERVICE_INFO_HPP_
+#ifndef RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_
+#define RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_
 
 #include "rmw_opendds_shared_cpp/opendds_include.hpp"
 
@@ -30,4 +30,4 @@ struct OpenDDSStaticServiceInfo
 };
 }  // extern "C"
 
-#endif  // RMW_OPENDDS_CPP__CONNEXT_STATIC_SERVICE_INFO_HPP_
+#endif  // RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
@@ -24,8 +24,8 @@ extern "C"
 struct OpenDDSStaticServiceInfo
 {
   void * replier_;
-  DDS::DataReader * request_datareader_;
-  DDS::ReadCondition * read_condition_;
+  DDS::DataReader_var request_datareader_;
+  DDS::ReadCondition_var read_condition_;
   const service_type_support_callbacks_t * callbacks_;
 };
 }  // extern "C"

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_service_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_
-#define RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_
+#ifndef RMW_OPENDDS_CPP__OPENDDS_STATIC_SERVICE_INFO_HPP_
+#define RMW_OPENDDS_CPP__OPENDDS_STATIC_SERVICE_INFO_HPP_
 
 #include "rmw_opendds_shared_cpp/opendds_include.hpp"
 
@@ -30,4 +30,4 @@ struct OpenDDSStaticServiceInfo
 };
 }  // extern "C"
 
-#endif  // RMW_OPENDDS_STATIC_SERVICE_INFO_HPP_
+#endif  // RMW_OPENDDS_CPP__OPENDDS_STATIC_SERVICE_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_subscriber_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_subscriber_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
-#define RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
+#ifndef RMW_OPENDDS_CPP__OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
+#define RMW_OPENDDS_CPP__OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
 
 #include <atomic>
 
@@ -27,21 +27,26 @@ extern "C"
 {
 struct OpenDDSStaticSubscriberInfo
 {
-  DDS::Subscriber * dds_subscriber_;
+  DDS::Subscriber_var dds_subscriber_;
   OpenDDSSubscriberListener * listener_;
-  DDS::DataReader * topic_reader_;
-  DDS::ReadCondition * read_condition_;
+  DDS::DataReader_var topic_reader_;
+  DDS::ReadCondition_var read_condition_;
   bool ignore_local_publications;
   const message_type_support_callbacks_t * callbacks_;
+  OpenDDSStaticSubscriberInfo() :
+    dds_subscriber_(),
+    listener_(nullptr),
+    topic_reader_(),
+    read_condition_(),
+    ignore_local_publications(false),
+    callbacks_(nullptr) {}
 };
 }  // extern "C"
 
 class OpenDDSSubscriberListener : public DDS::SubscriberListener
 {
 public:
-  virtual void on_subscription_matched(
-    DDS::DataReader *,
-    const DDS::SubscriptionMatchedStatus & status)
+  virtual void on_subscription_matched(DDS::DataReader *, const DDS::SubscriptionMatchedStatus & status)
   {
     current_count_ = status.current_count;
   }
@@ -51,8 +56,43 @@ public:
     return current_count_;
   }
 
+  void on_data_available(DDS::DataReader_ptr)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_data_available()\n")));
+  }
+
+  void on_requested_deadline_missed(DDS::DataReader_ptr, const DDS::RequestedDeadlineMissedStatus&)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_deadline_missed()\n")));
+  }
+
+  void on_requested_incompatible_qos(DDS::DataReader_ptr, const DDS::RequestedIncompatibleQosStatus&)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_requested_incompatible_qos()\n")));
+  }
+
+  void on_liveliness_changed(DDS::DataReader_ptr, const DDS::LivelinessChangedStatus&)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_liveliness_changed()\n")));
+  }
+
+  void on_sample_rejected(DDS::DataReader_ptr, const DDS::SampleRejectedStatus&)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_rejected()\n")));
+  }
+
+  void on_sample_lost(DDS::DataReader_ptr, const DDS::SampleLostStatus&)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_sample_lost()\n")));
+  }
+
+  void on_data_on_readers(DDS::Subscriber_ptr)
+  {
+    ACE_DEBUG((LM_DEBUG, ACE_TEXT("%N:%l: INFO: on_data_on_readers()\n")));
+  }
+
 private:
   std::atomic<std::size_t> current_count_;
 };
 
-#endif  // RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
+#endif  // RMW_OPENDDS_CPP__OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_

--- a/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_subscriber_info.hpp
+++ b/rmw_opendds_cpp/include/rmw_opendds_cpp/opendds_static_subscriber_info.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RMW_OPENDDS_CPP__CONNEXT_STATIC_SUBSCRIBER_INFO_HPP_
-#define RMW_OPENDDS_CPP__CONNEXT_STATIC_SUBSCRIBER_INFO_HPP_
+#ifndef RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
+#define RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_
 
 #include <atomic>
 
@@ -55,4 +55,4 @@ private:
   std::atomic<std::size_t> current_count_;
 };
 
-#endif  // RMW_OPENDDS_CPP__CONNEXT_STATIC_SUBSCRIBER_INFO_HPP_
+#endif  // RMW_OPENDDS_STATIC_SUBSCRIBER_INFO_HPP_

--- a/rmw_opendds_cpp/src/get_subscriber.cpp
+++ b/rmw_opendds_cpp/src/get_subscriber.cpp
@@ -20,7 +20,7 @@
 namespace rmw_opendds_cpp
 {
 
-DDS::DataReader *
+DDS::DataReader_var
 get_data_reader(rmw_subscription_t * subscription)
 {
   if (!subscription) {

--- a/rmw_opendds_cpp/src/process_topic_and_service_names.cpp
+++ b/rmw_opendds_cpp/src/process_topic_and_service_names.cpp
@@ -22,7 +22,6 @@
 
 #include "rmw_opendds_shared_cpp/namespace_prefix.hpp"
 #include "rmw_opendds_shared_cpp/opendds_include.hpp"
-#include <iostream> //?? temp
 
 bool
 _process_topic_name(
@@ -30,7 +29,6 @@ _process_topic_name(
   bool avoid_ros_namespace_conventions,
   char ** topic_str)
 {
-  std::cout << "topic_name[" << topic_name << "], avoid_ros_namespace_conventions:" << avoid_ros_namespace_conventions << '\n'; //??
   bool success = true;
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   const char * topic_prefix = avoid_ros_namespace_conventions ? "" : ros_topic_prefix;
@@ -42,7 +40,6 @@ _process_topic_name(
     RMW_SET_ERROR_MSG("could not allocate memory for topic string");
     success = false;
   }
-  std::cout << "topic_prefix[" << topic_prefix << "], topic_str[" << *topic_str << "]\n"; //??
   return success;
 }
 
@@ -54,7 +51,6 @@ _process_service_name(
   char ** response_topic_str)
 {
   bool success = true;
-  std::cout << "service_name[" << service_name << "], avoid_ros_namespace_conventions:" << avoid_ros_namespace_conventions << '\n'; //??
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   const char * rq_pfx = avoid_ros_namespace_conventions ? "" : ros_service_requester_prefix;
   const char * rp_pfx = avoid_ros_namespace_conventions ? "" : ros_service_response_prefix;

--- a/rmw_opendds_cpp/src/process_topic_and_service_names.cpp
+++ b/rmw_opendds_cpp/src/process_topic_and_service_names.cpp
@@ -31,25 +31,14 @@ _process_topic_name(
 {
   bool success = true;
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
-
-  const char * topic_prefix = "";
-  char * concat_str = nullptr;
-
-  if (!avoid_ros_namespace_conventions) {
-    topic_prefix = ros_topic_prefix;
-  }
-
-  concat_str = rcutils_format_string(allocator, "%s%s", topic_prefix, topic_name);
-  if (!concat_str) {
+  const char * topic_prefix = avoid_ros_namespace_conventions ? "" : ros_topic_prefix;
+  char * concat_str = rcutils_format_string(allocator, "%s%s", topic_prefix, topic_name);
+  if (concat_str) {
+    *topic_str = CORBA::string_dup(concat_str);
+    allocator.deallocate(concat_str, allocator.state);
+  } else {
     RMW_SET_ERROR_MSG("could not allocate memory for topic string");
     success = false;
-    goto end;
-  }
-  *topic_str = CORBA::string_dup(concat_str);
-
-end:
-  if (concat_str) {
-    allocator.deallocate(concat_str, allocator.state);
   }
   return success;
 }

--- a/rmw_opendds_cpp/src/rmw_client.cpp
+++ b/rmw_opendds_cpp/src/rmw_client.cpp
@@ -42,12 +42,11 @@ rmw_create_client(
   const rmw_qos_profile_t * qos_profile)
 {
   if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+    RMW_SET_ERROR_MSG("node is null");
     return NULL;
   }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    node handle,
-    node->implementation_identifier, opendds_identifier,
+    node handle, node->implementation_identifier, opendds_identifier,
     return NULL)
 
   const rosidl_service_type_support_t * type_support = rmw_get_service_type_support(type_supports);
@@ -62,12 +61,12 @@ rmw_create_client(
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
   if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
+    RMW_SET_ERROR_MSG("node info is null");
     return NULL;
   }
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
+    RMW_SET_ERROR_MSG("participant is null");
     return NULL;
   }
 
@@ -110,7 +109,6 @@ rmw_create_client(
     goto fail;
   }
 
-  //?? get_default_publisher_qos or pass DDS::Publisher* to get_datawriter_qos
   if (!get_datawriter_qos(participant, *qos_profile, datawriter_qos)) {
     // error string was set within the function
     goto fail;
@@ -125,7 +123,7 @@ rmw_create_client(
   {
     goto fail;
   }
-
+/*
   requester = callbacks->create_requester(
     participant, request_topic_str, response_topic_str,
     &datareader_qos, &datawriter_qos,
@@ -176,7 +174,7 @@ rmw_create_client(
     RMW_SET_ERROR_MSG("failed to create read condition");
     goto fail;
   }
-
+*/
   buf = rmw_allocate(sizeof(OpenDDSStaticClientInfo));
   if (!buf) {
     RMW_SET_ERROR_MSG("failed to allocate memory");
@@ -185,10 +183,10 @@ rmw_create_client(
   // Use a placement new to construct the OpenDDSStaticClientInfo in the preallocated buffer.
   RMW_TRY_PLACEMENT_NEW(client_info, buf, goto fail, OpenDDSStaticClientInfo, )
   buf = nullptr;  // Only free the client_info pointer; don't need the buf pointer anymore.
-  client_info->requester_ = requester;
-  client_info->callbacks_ = callbacks;
-  client_info->response_datareader_ = response_datareader;
-  client_info->read_condition_ = read_condition;
+  client_info->requester_ = NULL; //requester;
+  client_info->callbacks_ = NULL; //callbacks;
+  client_info->response_datareader_ = NULL; //response_datareader;
+  client_info->read_condition_ = NULL; //read_condition;
 
   client->implementation_identifier = opendds_identifier;
   client->data = client_info;
@@ -198,7 +196,7 @@ rmw_create_client(
     goto fail;
   }
   memcpy(const_cast<char *>(client->service_name), service_name, strlen(service_name) + 1);
-
+/*
   mangled_name =
     response_datareader->get_topicdescription()->get_name();
   node_info->subscriber_listener->add_information(
@@ -228,7 +226,7 @@ rmw_create_client(
   fprintf(stderr, "Publisher address %p\n", static_cast<void *>(dds_publisher));
   fprintf(stderr, "******\n");
 #endif
-
+*/
   return client;
 fail:
   if (request_topic_str) {

--- a/rmw_opendds_cpp/src/rmw_client.cpp
+++ b/rmw_opendds_cpp/src/rmw_client.cpp
@@ -103,7 +103,8 @@ rmw_create_client(
     RMW_SET_ERROR_MSG("failed to allocate client");
     goto fail;
   }
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement client properly.
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
     // error string was set within the function
     goto fail;
@@ -123,7 +124,8 @@ rmw_create_client(
   {
     goto fail;
   }
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement client properly.
   requester = callbacks->create_requester(
     participant, request_topic_str, response_topic_str,
     &datareader_qos, &datawriter_qos,
@@ -183,10 +185,10 @@ rmw_create_client(
   // Use a placement new to construct the OpenDDSStaticClientInfo in the preallocated buffer.
   RMW_TRY_PLACEMENT_NEW(client_info, buf, goto fail, OpenDDSStaticClientInfo, )
   buf = nullptr;  // Only free the client_info pointer; don't need the buf pointer anymore.
-  client_info->requester_ = NULL; //requester;
-  client_info->callbacks_ = NULL; //callbacks;
-  client_info->response_datareader_ = NULL; //response_datareader;
-  client_info->read_condition_ = NULL; //read_condition;
+  client_info->requester_ = nullptr; //requester;
+  client_info->callbacks_ = nullptr; //callbacks;
+  client_info->response_datareader_ = nullptr; //response_datareader;
+  client_info->read_condition_ = nullptr; //read_condition;
 
   client->implementation_identifier = opendds_identifier;
   client->data = client_info;
@@ -196,7 +198,8 @@ rmw_create_client(
     goto fail;
   }
   memcpy(const_cast<char *>(client->service_name), service_name, strlen(service_name) + 1);
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement client properly.
   mangled_name =
     response_datareader->get_topicdescription()->get_name();
   node_info->subscriber_listener->add_information(

--- a/rmw_opendds_cpp/src/rmw_client.cpp
+++ b/rmw_opendds_cpp/src/rmw_client.cpp
@@ -50,7 +50,10 @@ rmw_create_client(
     node->implementation_identifier, opendds_identifier,
     return NULL)
 
-  RMW_OPENDDS_EXTRACT_SERVICE_TYPESUPPORT(type_supports, type_support, NULL)
+  const rosidl_service_type_support_t * type_support = rmw_get_service_type_support(type_supports);
+  if (!type_support) {
+    return NULL;
+  }
 
   if (!qos_profile) {
     RMW_SET_ERROR_MSG("qos_profile is null");
@@ -101,12 +104,12 @@ rmw_create_client(
     RMW_SET_ERROR_MSG("failed to allocate client");
     goto fail;
   }
-
+/*
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
     // error string was set within the function
     goto fail;
   }
-/*
+
   //?? get_default_publisher_qos or pass DDS::Publisher* to get_datawriter_qos
   if (!get_datawriter_qos(participant, *qos_profile, datawriter_qos)) {
     // error string was set within the function

--- a/rmw_opendds_cpp/src/rmw_client.cpp
+++ b/rmw_opendds_cpp/src/rmw_client.cpp
@@ -106,12 +106,13 @@ rmw_create_client(
     // error string was set within the function
     goto fail;
   }
-
+/*
+  //?? get_default_publisher_qos or pass DDS::Publisher* to get_datawriter_qos
   if (!get_datawriter_qos(participant, *qos_profile, datawriter_qos)) {
     // error string was set within the function
     goto fail;
   }
-
+*/
   // allocating memory for request topic and response topic strings
   if (!_process_service_name(
       service_name,

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -60,6 +60,7 @@ publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_str
   instance.serialized_data.length(static_cast<CORBA::ULong>(cdr_stream->buffer_length));
   std::memcpy(instance.serialized_data.get_buffer(), cdr_stream->buffer, cdr_stream->buffer_length);
 
+  std::cout << "publish writer->write\n";
   DDS::ReturnCode_t status = writer->write(instance, DDS::HANDLE_NIL);
   return status == DDS::RETCODE_OK;
 }
@@ -72,6 +73,7 @@ rmw_publish(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation)
 {
+  std::cout << "rmw_publish----->\n";
   if (!publisher) {
     RMW_SET_ERROR_MSG("publisher is null");
     return RMW_RET_ERROR;
@@ -102,8 +104,9 @@ rmw_publish(
 
   auto ret = RMW_RET_ERROR;
   rcutils_uint8_array_t cdr_stream = rcutils_get_zero_initialized_uint8_array();
-  cdr_stream.allocator = rcutils_get_default_allocator(); //?? not using the given allocation
+  cdr_stream.allocator = rcutils_get_default_allocator();
   try {
+/*
     if (!callbacks->to_cdr_stream(ros_message, &cdr_stream)) {
       throw std::string("failed to convert ros_message to cdr stream");
     }
@@ -113,6 +116,7 @@ rmw_publish(
     if (!cdr_stream.buffer) {
       throw std::string("no serialized message attached");
     }
+*/
     if (!publish(writer, &cdr_stream)) {
       throw std::string("failed to publish message");
     }
@@ -123,6 +127,7 @@ rmw_publish(
     RMW_SET_ERROR_MSG("rmw_publish failed");
   }
   cdr_stream.allocator.deallocate(cdr_stream.buffer, cdr_stream.allocator.state);
+  std::cout << "rmw_publish return " << ret << '\n'; //??
   return ret;
 }
 

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -104,7 +104,7 @@ rmw_publish(
   rcutils_uint8_array_t cdr_stream = rcutils_get_zero_initialized_uint8_array();
   cdr_stream.allocator = rcutils_get_default_allocator();
   try {
-/*
+/*  TODO: uncommnet this block when type support is ready.
     if (!callbacks->to_cdr_stream(ros_message, &cdr_stream)) {
       throw std::string("failed to convert ros_message to cdr stream");
     }

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -21,17 +21,27 @@
 #include "rmw_opendds_cpp/opendds_static_publisher_info.hpp"
 #include "rmw_opendds_cpp/identifier.hpp"
 
-#include "dds/DCPS/DataWriterImpl.h"
+//#include "dds/DCPS/DataWriterImpl.h"
+#include <dds/DdsDcpsGuidC.h>
+#include <dds/DCPS/RepoIdBuilder.h>
 #include "opendds_static_serialized_dataTypeSupportC.h"
 
 #include <ace/Message_Block.h>
 
+OpenDDS::DCPS::RepoId createID(long participantId, long key, CORBA::Octet kind) {
+  OpenDDS::DCPS::RepoIdBuilder idBd;
+  idBd.federationId(0x12345678);     // guidPrefix1
+  idBd.participantId(participantId); // guidPrefix2
+  idBd.entityKey(key);
+  idBd.entityKind(kind);
+  return idBd;
+}
+
 bool
 publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_stream)
 {
-  OpenDDSStaticSerializedDataDataWriter * data_writer =
-    OpenDDSStaticSerializedDataDataWriter::_narrow(dds_data_writer);
-  if (!data_writer) {
+  OpenDDSStaticSerializedDataDataWriter * writer = OpenDDSStaticSerializedDataDataWriter::_narrow(dds_data_writer);
+  if (!writer) {
     RMW_SET_ERROR_MSG("failed to narrow data writer");
     return false;
   }
@@ -41,28 +51,18 @@ publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_str
     return false;
   }
 
-  OpenDDSStaticSerializedData_var instance = new OpenDDSStaticSerializedData();
-
-  // TODO: This implementation may be  temporary until typesupport is finalized
-
+  OpenDDSStaticSerializedData instance;
+  // TODO: This implementation is temporary until typesupport is finalized.
   // Populate instance
-  instance->serialized_data.length(static_cast<CORBA::ULong>(cdr_stream->buffer_length));
-  std::memcpy(instance->serialized_data.get_buffer(), cdr_stream->buffer, cdr_stream->buffer_length);
+  // Since OpenDDSStaticSerializedDataDataWriter is not a DataWriterImpl, a fake id is used here for testing.
+  OpenDDS::DCPS::RepoId id = createID(0x11111111, 0x123456, OpenDDS::DCPS::ENTITYKIND_USER_WRITER_WITH_KEY);
+  instance.serialized_key.length(KEY_HASH_LENGTH_16);
+  instance.serialized_data.length(static_cast<CORBA::ULong>(cdr_stream->buffer_length));
+  std::memcpy(instance.key_hash, &id, KEY_HASH_LENGTH_16);
+  std::memcpy(instance.serialized_key.get_buffer(), &id, KEY_HASH_LENGTH_16);
+  std::memcpy(instance.serialized_data.get_buffer(), cdr_stream->buffer, cdr_stream->buffer_length);
 
-  OpenDDS::DCPS::DataWriterImpl* writer
-    = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(dds_data_writer);
-
-  OpenDDS::DCPS::Message_Block_Ptr data(new ACE_Message_Block(KEY_HASH_LENGTH_16, ACE_Message_Block::MB_DATA, 0, 0, 0, 0));
-  OpenDDS::DCPS::Serializer ser(data.get());
-  ser << writer->get_publication_id();
-
-  instance->serialized_key.length(KEY_HASH_LENGTH_16);
-  std::memcpy(instance->serialized_key.get_buffer(), data.get(), KEY_HASH_LENGTH_16);
-
-  std::memcpy(instance->key_hash, data.get(), KEY_HASH_LENGTH_16);
-
-  DDS::ReturnCode_t status = data_writer->write(*instance, DDS::HANDLE_NIL);
-
+  DDS::ReturnCode_t status = writer->write(instance, DDS::HANDLE_NIL);
   return status == DDS::RETCODE_OK;
 }
 
@@ -75,61 +75,55 @@ rmw_publish(
   rmw_publisher_allocation_t * allocation)
 {
   if (!publisher) {
-    RMW_SET_ERROR_MSG("publisher handle is null");
+    RMW_SET_ERROR_MSG("publisher is null");
     return RMW_RET_ERROR;
   }
   if (publisher->implementation_identifier != opendds_identifier) {
-    RMW_SET_ERROR_MSG("publisher handle is not from this rmw implementation");
+    RMW_SET_ERROR_MSG("publisher is not from this rmw implementation");
     return RMW_RET_ERROR;
   }
   if (!ros_message) {
-    RMW_SET_ERROR_MSG("ros message handle is null");
+    RMW_SET_ERROR_MSG("ros message is null");
     return RMW_RET_ERROR;
   }
-
-  OpenDDSStaticPublisherInfo * publisher_info =
-    static_cast<OpenDDSStaticPublisherInfo *>(publisher->data);
-  if (!publisher_info) {
-    RMW_SET_ERROR_MSG("publisher info handle is null");
+  OpenDDSStaticPublisherInfo * info = static_cast<OpenDDSStaticPublisherInfo *>(publisher->data);
+  if (!info) {
+    RMW_SET_ERROR_MSG("publisher info is null");
     return RMW_RET_ERROR;
   }
-  const message_type_support_callbacks_t * callbacks = publisher_info->callbacks_;
+  const message_type_support_callbacks_t * callbacks = info->callbacks_;
   if (!callbacks) {
-    RMW_SET_ERROR_MSG("callbacks handle is null");
+    RMW_SET_ERROR_MSG("publisher info callbacks is null");
     return RMW_RET_ERROR;
   }
-  DDS::DataWriter_var topic_writer = publisher_info->topic_writer_;
-  if (!topic_writer) {
-    RMW_SET_ERROR_MSG("topic writer handle is null");
+  DDS::DataWriter_var writer = info->topic_writer_;
+  if (!writer) {
+    RMW_SET_ERROR_MSG("topic writer is null");
     return RMW_RET_ERROR;
   }
 
-  auto ret = RMW_RET_OK;
+  auto ret = RMW_RET_ERROR;
   rcutils_uint8_array_t cdr_stream = rcutils_get_zero_initialized_uint8_array();
-  cdr_stream.allocator = rcutils_get_default_allocator();
-
-  if (!callbacks->to_cdr_stream(ros_message, &cdr_stream)) {
-    RMW_SET_ERROR_MSG("failed to convert ros_message to cdr stream");
-    ret = RMW_RET_ERROR;
-    goto fail;
+  cdr_stream.allocator = rcutils_get_default_allocator(); //?? not using the given allocation
+  try {
+    if (!callbacks->to_cdr_stream(ros_message, &cdr_stream)) {
+      throw std::string("failed to convert ros_message to cdr stream");
+    }
+    if (cdr_stream.buffer_length == 0) {
+      throw std::string("no message length set");
+    }
+    if (!cdr_stream.buffer) {
+      throw std::string("no serialized message attached");
+    }
+    if (!publish(writer, &cdr_stream)) {
+      throw std::string("failed to publish message");
+    }
+    ret = RMW_RET_OK;
+  } catch (const std::string& e) {
+    RMW_SET_ERROR_MSG(e.c_str());
+  } catch (...) {
+    RMW_SET_ERROR_MSG("rmw_publish failed");
   }
-  if (cdr_stream.buffer_length == 0) {
-    RMW_SET_ERROR_MSG("no message length set");
-    ret = RMW_RET_ERROR;
-    goto fail;
-  }
-  if (!cdr_stream.buffer) {
-    RMW_SET_ERROR_MSG("no serialized message attached");
-    ret = RMW_RET_ERROR;
-    goto fail;
-  }
-  if (!publish(topic_writer, &cdr_stream)) {
-    RMW_SET_ERROR_MSG("failed to publish message");
-    ret = RMW_RET_ERROR;
-    goto fail;
-  }
-
-fail:
   cdr_stream.allocator.deallocate(cdr_stream.buffer, cdr_stream.allocator.state);
   return ret;
 }
@@ -141,37 +135,35 @@ rmw_publish_serialized_message(
   rmw_publisher_allocation_t * allocation)
 {
   if (!publisher) {
-    RMW_SET_ERROR_MSG("publisher handle is null");
+    RMW_SET_ERROR_MSG("publisher is null");
     return RMW_RET_ERROR;
   }
   if (publisher->implementation_identifier != opendds_identifier) {
-    RMW_SET_ERROR_MSG("publisher handle is not from this rmw implementation");
+    RMW_SET_ERROR_MSG("publisher is not from this rmw implementation");
     return RMW_RET_ERROR;
   }
   if (!serialized_message) {
-    RMW_SET_ERROR_MSG("serialized message handle is null");
+    RMW_SET_ERROR_MSG("serialized message is null");
     return RMW_RET_ERROR;
   }
 
-  OpenDDSStaticPublisherInfo * publisher_info =
-    static_cast<OpenDDSStaticPublisherInfo *>(publisher->data);
-  if (!publisher_info) {
-    RMW_SET_ERROR_MSG("publisher info handle is null");
+  OpenDDSStaticPublisherInfo * info = static_cast<OpenDDSStaticPublisherInfo *>(publisher->data);
+  if (!info) {
+    RMW_SET_ERROR_MSG("publisher info is null");
     return RMW_RET_ERROR;
   }
-  const message_type_support_callbacks_t * callbacks = publisher_info->callbacks_;
+  const message_type_support_callbacks_t * callbacks = info->callbacks_;
   if (!callbacks) {
-    RMW_SET_ERROR_MSG("callbacks handle is null");
+    RMW_SET_ERROR_MSG("publisher info callbacks is null");
     return RMW_RET_ERROR;
   }
-  DDS::DataWriter_var topic_writer = publisher_info->topic_writer_;
-  if (!topic_writer) {
-    RMW_SET_ERROR_MSG("topic writer handle is null");
+  DDS::DataWriter_var writer = info->topic_writer_;
+  if (!writer) {
+    RMW_SET_ERROR_MSG("topic writer is null");
     return RMW_RET_ERROR;
   }
 
-  bool published = publish(topic_writer, serialized_message);
-  if (!published) {
+  if (!publish(writer, serialized_message)) {
     RMW_SET_ERROR_MSG("failed to publish message");
     return RMW_RET_ERROR;
   }

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -60,7 +60,6 @@ publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_str
   instance.serialized_data.length(static_cast<CORBA::ULong>(cdr_stream->buffer_length));
   std::memcpy(instance.serialized_data.get_buffer(), cdr_stream->buffer, cdr_stream->buffer_length);
 
-  std::cout << "publish writer->write\n";
   DDS::ReturnCode_t status = writer->write(instance, DDS::HANDLE_NIL);
   return status == DDS::RETCODE_OK;
 }
@@ -73,7 +72,6 @@ rmw_publish(
   const void * ros_message,
   rmw_publisher_allocation_t * allocation)
 {
-  std::cout << "rmw_publish----->\n";
   if (!publisher) {
     RMW_SET_ERROR_MSG("publisher is null");
     return RMW_RET_ERROR;
@@ -127,7 +125,6 @@ rmw_publish(
     RMW_SET_ERROR_MSG("rmw_publish failed");
   }
   cdr_stream.allocator.deallocate(cdr_stream.buffer, cdr_stream.allocator.state);
-  std::cout << "rmw_publish return " << ret << '\n'; //??
   return ret;
 }
 

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -32,19 +32,17 @@ bool set_key(OpenDDSStaticSerializedData & instance, DDS::DataWriter * dds_data_
     RMW_SET_ERROR_MSG("failed to cast dds_data_writer to DataWriterImpl");
     return false;
   }
-  OpenDDS::DCPS::Message_Block_Ptr key(new ACE_Message_Block(KEY_HASH_LENGTH_16, ACE_Message_Block::MB_DATA, 0, 0, 0, 0));
-  OpenDDS::DCPS::Serializer ser(key.get());
-  ser << dwImpl->get_publication_id();
+  OpenDDS::DCPS::RepoId id = dwImpl->get_publication_id();
+  std::memcpy(instance.key_hash, &id, KEY_HASH_LENGTH_16);
   instance.serialized_key.length(KEY_HASH_LENGTH_16);
-  std::memcpy(instance.key_hash, key.get(), KEY_HASH_LENGTH_16);
-  std::memcpy(instance.serialized_key.get_buffer(), key.get(), KEY_HASH_LENGTH_16);
+  std::memcpy(instance.serialized_key.get_buffer(), &id, KEY_HASH_LENGTH_16);
   return true;
 }
 
 bool
 publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_stream)
 {
-  OpenDDSStaticSerializedDataDataWriter * writer = OpenDDSStaticSerializedDataDataWriter::_narrow(dds_data_writer);
+  OpenDDSStaticSerializedDataDataWriter_var writer = OpenDDSStaticSerializedDataDataWriter::_narrow(dds_data_writer);
   if (!writer) {
     RMW_SET_ERROR_MSG("failed to narrow data writer");
     return false;

--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -100,54 +100,55 @@ rmw_create_publisher(
 {
   if (!node) {
     RMW_SET_ERROR_MSG("node is null");
-    return NULL;
+    return nullptr;
   }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node handle,
     node->implementation_identifier, opendds_identifier,
-    return NULL)
+    return nullptr)
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
   if (!node_info) {
     RMW_SET_ERROR_MSG("node info is null");
-    return NULL;
+    return nullptr;
   }
 
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
     RMW_SET_ERROR_MSG("participant is null");
-    return NULL;
+    return nullptr;
   }
 
   // message type support
   const rosidl_message_type_support_t * type_support = rmw_get_message_type_support(type_supports);
   if (!type_support) {
-    return NULL;
+    return nullptr;
   }
   std::cout << "type_support(" << type_support->typesupport_identifier << ", " << type_support->data << ", " << type_support->func << ")\n"; //??
   auto callbacks = static_cast<const message_type_support_callbacks_t*>(type_support->data);
   if (!callbacks) {
     RMW_SET_ERROR_MSG("callbacks handle is null");
-    return NULL;
+    return nullptr;
   }
   std::string type_name = _create_type_name(callbacks, "msg");
   OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
   if (ts->register_type(participant, type_name.c_str()) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to register OpenDDS type");
-    return NULL;
+    return nullptr;
   }
 
   if (!topic_name || strlen(topic_name) == 0) {
     RMW_SET_ERROR_MSG("publisher topic_name is null or empty");
-    return NULL;
+    return nullptr;
   }
   if (!qos_policies) {
     RMW_SET_ERROR_MSG("qos_policies is null");
-    return NULL;
+    return nullptr;
   }
   CORBA::String_var topic_str;
   if (!_process_topic_name(topic_name, qos_policies->avoid_ros_namespace_conventions, &topic_str.out())) {
-    throw std::string("failed to allocate memory for topic_str");
+    RMW_SET_ERROR_MSG("failed to allocate memory for topic_str");
+    return nullptr;
   }
   std::cout << "type_name[" << type_name << "], topic_name[" << topic_name << "], topic_str[" << topic_str << "]\n"; //??
 

--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -123,7 +123,6 @@ rmw_create_publisher(
   if (!type_support) {
     return nullptr;
   }
-  std::cout << "type_support(" << type_support->typesupport_identifier << ", " << type_support->data << ", " << type_support->func << ")\n"; //??
   auto callbacks = static_cast<const message_type_support_callbacks_t*>(type_support->data);
   if (!callbacks) {
     RMW_SET_ERROR_MSG("callbacks handle is null");
@@ -149,7 +148,6 @@ rmw_create_publisher(
     RMW_SET_ERROR_MSG("failed to allocate memory for topic_str");
     return nullptr;
   }
-  std::cout << "type_name[" << type_name << "], topic_name[" << topic_name << "], topic_str[" << topic_str << "]\n"; //??
 
   // find or create DDS::Topic
   DDS::TopicDescription_var topic_description = participant->lookup_topicdescription(topic_str.in());

--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -63,6 +63,31 @@ rmw_fini_publisher_allocation(rmw_publisher_allocation_t * allocation)
   return RMW_RET_ERROR;
 }
 
+void clean_publisher(rmw_publisher_t * publisher){
+  if (!publisher) {
+    return;
+  }
+
+  auto info = static_cast<OpenDDSStaticPublisherInfo*>(publisher->data);
+  if (info) {
+    if (info->listener_) {
+      RMW_TRY_DESTRUCTOR(info->listener_->~OpenDDSPublisherListener(), OpenDDSPublisherListener,)
+      rmw_free(info->listener_);
+      info->listener_ = nullptr;
+    }
+
+    RMW_TRY_DESTRUCTOR(info->~OpenDDSStaticPublisherInfo(), OpenDDSStaticPublisherInfo,)
+    rmw_free(info);
+    publisher->data = nullptr;
+  }
+
+  if (publisher->topic_name) {
+    rmw_free(const_cast<char *>(publisher->topic_name));
+  }
+
+  rmw_publisher_free(publisher);
+}
+
 rmw_publisher_t *
 rmw_create_publisher(
   const rmw_node_t * node,
@@ -72,7 +97,7 @@ rmw_create_publisher(
   const rmw_publisher_options_t * publisher_options)
 {
   if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+    RMW_SET_ERROR_MSG("node is null");
     return NULL;
   }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
@@ -83,7 +108,7 @@ rmw_create_publisher(
   RMW_OPENDDS_EXTRACT_MESSAGE_TYPESUPPORT(type_supports, type_support, NULL)
 
   if (!topic_name || strlen(topic_name) == 0) {
-    RMW_SET_ERROR_MSG("publisher topic is null or empty string");
+    RMW_SET_ERROR_MSG("publisher topic_name is null or empty");
     return NULL;
   }
 
@@ -94,12 +119,12 @@ rmw_create_publisher(
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
   if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
+    RMW_SET_ERROR_MSG("node info is null");
     return NULL;
   }
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
+    RMW_SET_ERROR_MSG("participant is null");
     return NULL;
   }
 
@@ -113,192 +138,139 @@ rmw_create_publisher(
   // TODO: TypeCode and susequent call to register external type have been removed
   // May need to implement something similar after IDL type support is finalized
 
-  std::string type_name = _create_type_name(callbacks, "msg");
-
-  void * info_buf = nullptr;
-  void * listener_buf = nullptr;
-  OpenDDSPublisherListener * publisher_listener = nullptr;
-  OpenDDSStaticPublisherInfo * publisher_info = nullptr;
   rmw_publisher_t * publisher = nullptr;
-  std::string mangled_name = "";
-  OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
-
+  void * buf = nullptr;
   char * topic_str = nullptr;
-
   try {
-    try {
-      // Begin initializing elements
-      publisher = rmw_publisher_allocate();
-      if (!publisher) {
-        throw std::string("failed to allocate publisher");
-      }
+    publisher = rmw_publisher_allocate();
+    if (!publisher) {
+      throw std::string("failed to allocate publisher");
+    }
+    publisher->implementation_identifier = opendds_identifier;
+    publisher->data = nullptr;
+    publisher->topic_name = nullptr; //?? publisher->topic_name = topic_name;
+    if (publisher_options) {
+      publisher->options = *publisher_options;
+    }
+    publisher->can_loan_messages = false;
 
-      publisher->can_loan_messages = false;
+    buf = rmw_allocate(sizeof(OpenDDSStaticPublisherInfo));
+    if (!buf) {
+      throw std::string("failed to allocate memory for publisher info");
+    }
+    OpenDDSStaticPublisherInfo * publisher_info = nullptr;
+    RMW_TRY_PLACEMENT_NEW(publisher_info, buf, throw 1, OpenDDSStaticPublisherInfo,)
+    publisher->data = publisher_info;
+    buf = nullptr;
 
-      // TODO: Register TypeSupport here ????????????????????????
-      if (ts->register_type(participant, "") != DDS::RETCODE_OK) {
-        throw std::string("failed to register OpenDDS type");
-      }
+    // TODO: Register TypeSupport here ????????????????????????
+    OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
+    if (ts->register_type(participant, "") != DDS::RETCODE_OK) {
+      throw std::string("failed to register OpenDDS type");
+    }
 
-      DDS::PublisherQos publisher_qos;
-      DDS::ReturnCode_t status = participant->get_default_publisher_qos(publisher_qos);
+    DDS::PublisherQos publisher_qos;
+    DDS::ReturnCode_t status = participant->get_default_publisher_qos(publisher_qos);
+    if (status != DDS::RETCODE_OK) {
+      throw std::string("failed to get default publisher qos");
+    }
+
+    if (!_process_topic_name(topic_name, qos_policies->avoid_ros_namespace_conventions, &topic_str)) {
+      throw std::string("failed to allocate memory for topic_str");
+    }
+
+    buf = rmw_allocate(sizeof(OpenDDSPublisherListener));
+    if (!buf) {
+      throw std::string("failed to allocate memory for publisher listener");
+    }
+    RMW_TRY_PLACEMENT_NEW(publisher_info->listener_, buf, throw 1, OpenDDSPublisherListener,)
+    buf = nullptr;
+
+    publisher_info->dds_publisher_ = participant->create_publisher(
+      publisher_qos, publisher_info->listener_, DDS::PUBLICATION_MATCHED_STATUS);
+    if (!publisher_info->dds_publisher_) {
+      throw std::string("failed to create publisher");
+    }
+
+    DDS::TopicDescription_var topic_description = participant->lookup_topicdescription(topic_str);
+    DDS::Topic_var topic;
+    std::string type_name = _create_type_name(callbacks, "msg");
+    if (!topic_description) {
+      DDS::TopicQos qos;
+      status = participant->get_default_topic_qos(qos);
       if (status != DDS::RETCODE_OK) {
-        throw std::string("failed to get default publisher qos");
+        throw std::string("failed to get default topic qos");
       }
-
-      // allocating memory for topic_str
-      if (!_process_topic_name(
-        topic_name,
-        qos_policies->avoid_ros_namespace_conventions,
-        &topic_str))
-      {
-        throw std::string("failed to allocate memory for topic_str");
+      topic = participant->create_topic(topic_str, type_name.c_str(), qos, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
+      if (!topic) {
+        throw std::string("failed to create topic");
       }
-
-      // Allocate memory for the PublisherListener object.
-      listener_buf = rmw_allocate(sizeof(OpenDDSPublisherListener));
-      if (!listener_buf) {
-        throw std::string("failed to allocate memory for publisher listener");
-      }
-      // Use a placement new to construct the PublisherListener in the preallocated buffer.
-      RMW_TRY_PLACEMENT_NEW(publisher_listener, listener_buf, throw std::string("Constructing PublisherListener failed"), OpenDDSPublisherListener, )
-        listener_buf = nullptr;  // Only free the buffer pointer.
-
-      DDS::Publisher_var dds_publisher = participant->create_publisher(
-        publisher_qos, publisher_listener, DDS::PUBLICATION_MATCHED_STATUS);
-      if (!dds_publisher) {
-        throw std::string("failed to create publisher");
-      }
-
-      DDS::TopicDescription_var topic_description = participant->lookup_topicdescription(topic_str);
-      DDS::Topic_var topic;
-      if (!topic_description) {
-        DDS::TopicQos default_topic_qos;
-        status = participant->get_default_topic_qos(default_topic_qos);
-        if (status != DDS::RETCODE_OK) {
-          throw std::string("failed to get default topic qos");
-        }
-
-        topic = participant->create_topic(
-          topic_str, type_name.c_str(),
-          default_topic_qos, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
-        if (!topic) {
-          throw std::string("failed to create topic");
-        }
-      }
-      else {
-        DDS::Duration_t timeout = { 0, 0 };
-        topic = participant->find_topic(topic_str, timeout);
-        if (!topic) {
-          throw std::string("failed to find topic");
-        }
-      }
-      CORBA::string_free(topic_str);
-      topic_str = nullptr;
-
-      DDS::DataWriterQos datawriter_qos;
-      if (!get_datawriter_qos(participant, *qos_policies, datawriter_qos)) {
-        // specific error was set within the function
-        throw std::string("get_datawriter_qos failed");
-      }
-
-      DDS::DataWriter_var topic_writer = dds_publisher->create_datawriter(
-        topic, datawriter_qos, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
-      if (!topic_writer) {
-        throw std::string("failed to create datawriter");
-      }
-
-      // Allocate memory for the OpenDDSStaticPublisherInfo object.
-      info_buf = rmw_allocate(sizeof(OpenDDSStaticPublisherInfo));
-      if (!info_buf) {
-        throw std::string("failed to allocate memory for publisher info");
-      }
-      // Use a placement new to construct the OpenDDSStaticPublisherInfo in the preallocated buffer.
-      RMW_TRY_PLACEMENT_NEW(publisher_info, info_buf, throw std::string("Constructing OpenDDSStaticPublisherInfo failed"), OpenDDSStaticPublisherInfo, )
-        info_buf = nullptr;  // Only free the publisher_info pointer; don't need the buf pointer anymore.
-      publisher_info->dds_publisher_ = dds_publisher;
-      publisher_info->topic_writer_ = topic_writer;
-      publisher_info->callbacks_ = callbacks;
-      publisher_info->publisher_gid.implementation_identifier = opendds_identifier;
-      publisher_info->listener_ = publisher_listener;
-      publisher_listener = nullptr;
-      static_assert(
-        sizeof(OpenDDSPublisherGID) <= RMW_GID_STORAGE_SIZE,
-        "RMW_GID_STORAGE_SIZE insufficient to store the rmw_opendds_cpp GID implemenation."
-        );
-      // Zero the data memory.
-      memset(publisher_info->publisher_gid.data, 0, RMW_GID_STORAGE_SIZE);
-      {
-        auto publisher_gid =
-          reinterpret_cast<OpenDDSPublisherGID*>(publisher_info->publisher_gid.data);
-        publisher_gid->publication_handle = topic_writer->get_instance_handle();
-      }
-      publisher_info->publisher_gid.implementation_identifier = opendds_identifier;
-
-      publisher->implementation_identifier = opendds_identifier;
-      publisher->data = publisher_info;
-      publisher->topic_name = reinterpret_cast<const char*>(rmw_allocate(strlen(topic_name) + 1));
-      if (!publisher->topic_name) {
-        throw std::string("failed to allocate memory for node name");
-      }
-      memcpy(const_cast<char*>(publisher->topic_name), topic_name, strlen(topic_name) + 1);
-
-      if (!qos_policies->avoid_ros_namespace_conventions) {
-        mangled_name =
-          topic_writer->get_topic()->get_name();
-      }
-      else {
-        mangled_name = topic_name;
-      }
-      node_info->publisher_listener->add_information(
-        node_info->participant->get_instance_handle(),
-        dds_publisher->get_instance_handle(),
-        mangled_name,
-        type_name,
-        EntityType::Publisher);
-      node_info->publisher_listener->trigger_graph_guard_condition();
-
-      // TODO: Log created publisher details: topic and address (?)
-
-      return publisher;
     }
-    catch (const std::string& sError) {
-      RMW_SET_ERROR_MSG("sError");
-      throw;
+    else {
+      DDS::Duration_t timeout = { 0, 0 };
+      topic = participant->find_topic(topic_str, timeout);
+      if (!topic) {
+        throw std::string("failed to find topic");
+      }
     }
+    CORBA::string_free(topic_str);
+    topic_str = nullptr;
+
+    DDS::DataWriterQos datawriter_qos;
+    if (!get_datawriter_qos(participant, *qos_policies, datawriter_qos)) {
+      // specific error was set within the function
+      throw std::string("get_datawriter_qos failed");
+    }
+
+    publisher_info->topic_writer_ = publisher_info->dds_publisher_->create_datawriter(
+      topic, datawriter_qos, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
+    if (!publisher_info->topic_writer_) {
+      throw std::string("failed to create datawriter");
+    }
+
+    publisher_info->callbacks_ = callbacks;
+    publisher_info->publisher_gid.implementation_identifier = opendds_identifier;
+
+    static_assert(sizeof(OpenDDSPublisherGID) <= RMW_GID_STORAGE_SIZE, "insufficient RMW_GID_STORAGE_SIZE");
+    // Zero the data memory.
+    memset(publisher_info->publisher_gid.data, 0, RMW_GID_STORAGE_SIZE);
+    {
+      auto publisher_gid = reinterpret_cast<OpenDDSPublisherGID*>(publisher_info->publisher_gid.data);
+      publisher_gid->publication_handle = publisher_info->topic_writer_->get_instance_handle();
+    }
+    publisher_info->publisher_gid.implementation_identifier = opendds_identifier;
+
+    publisher->topic_name = reinterpret_cast<const char*>(rmw_allocate(strlen(topic_name) + 1));
+    if (!publisher->topic_name) {
+      throw std::string("failed to allocate memory for node name");
+    }
+    memcpy(const_cast<char*>(publisher->topic_name), topic_name, strlen(topic_name) + 1);
+
+    std::string mangled_name = qos_policies->avoid_ros_namespace_conventions ?
+      topic_name : publisher_info->topic_writer_->get_topic()->get_name();
+    node_info->publisher_listener->add_information(node_info->participant->get_instance_handle(),
+      publisher_info->dds_publisher_->get_instance_handle(), mangled_name, type_name, EntityType::Publisher);
+    node_info->publisher_listener->trigger_graph_guard_condition();
+
+    // TODO: Log created publisher details: topic and address (?)
+
+    return publisher;
+
+  } catch (const std::string& e) {
+    RMW_SET_ERROR_MSG(e.c_str());
+  } catch (...) {
+    RMW_SET_ERROR_MSG("rmw_create_publisher failed");
   }
-  catch (...) {
-    if (topic_str) {
-      CORBA::string_free(topic_str);
-      topic_str = nullptr;
-    }
-    if (publisher) {
-      rmw_publisher_free(publisher);
-    }
-    if (publisher_listener) {
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        publisher_listener->~OpenDDSPublisherListener(), OpenDDSPublisherListener)
-        rmw_free(publisher_listener);
-    }
-    if (publisher_info) {
-      if (publisher_info->listener_) {
-        RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-          publisher_info->listener_->~OpenDDSPublisherListener(), OpenDDSPublisherListener)
-          rmw_free(publisher_info->listener_);
-      }
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        publisher_info->~OpenDDSStaticPublisherInfo(), OpenDDSStaticPublisherInfo)
-        rmw_free(publisher_info);
-    }
-    if (info_buf) {
-      rmw_free(info_buf);
-    }
-    if (listener_buf) {
-      rmw_free(listener_buf);
-    }
 
-    return NULL;
+  clean_publisher(publisher);
+  if (buf) {
+    rmw_free(buf);
   }
+  if (topic_str) {
+    CORBA::string_free(topic_str);
+    topic_str = nullptr;
+  }
+  return nullptr;
 }
 
 rmw_ret_t
@@ -307,7 +279,7 @@ rmw_publisher_count_matched_subscriptions(
   size_t * subscription_count)
 {
   if (!publisher) {
-    RMW_SET_ERROR_MSG("publisher handle is null");
+    RMW_SET_ERROR_MSG("publisher is null");
     return RMW_RET_INVALID_ARGUMENT;
   }
 
@@ -318,11 +290,11 @@ rmw_publisher_count_matched_subscriptions(
 
   auto info = static_cast<OpenDDSStaticPublisherInfo *>(publisher->data);
   if (!info) {
-    RMW_SET_ERROR_MSG("publisher internal data is invalid");
+    RMW_SET_ERROR_MSG("publisher info is null");
     return RMW_RET_ERROR;
   }
   if (!info->listener_) {
-    RMW_SET_ERROR_MSG("publisher internal listener is invalid");
+    RMW_SET_ERROR_MSG("publisher listener is null");
     return RMW_RET_ERROR;
   }
 
@@ -341,18 +313,18 @@ rmw_publisher_get_actual_qos(
 
   auto info = static_cast<OpenDDSStaticPublisherInfo*>(publisher->data);
   if (!info) {
-    RMW_SET_ERROR_MSG("publisher internal data is invalid");
+    RMW_SET_ERROR_MSG("publisher info is null");
     return RMW_RET_ERROR;
   }
   DDS::DataWriter_var data_writer = info->topic_writer_;
   if (!data_writer) {
-    RMW_SET_ERROR_MSG("publisher internal data writer is invalid");
+    RMW_SET_ERROR_MSG("publisher writer is null");
     return RMW_RET_ERROR;
   }
   DDS::DataWriterQos dds_qos;
   DDS::ReturnCode_t status = data_writer->get_qos(dds_qos);
   if (DDS::RETCODE_OK != status) {
-    RMW_SET_ERROR_MSG("publisher can't get data writer qos policies");
+    RMW_SET_ERROR_MSG("publisher writer get_qos failed");
     return RMW_RET_ERROR;
   }
 

--- a/rmw_opendds_cpp/src/rmw_request.cpp
+++ b/rmw_opendds_cpp/src/rmw_request.cpp
@@ -113,7 +113,7 @@ rmw_take_request(
 
   *taken = callbacks->take_request(replier, request_header, ros_request);
 */
-  *taken = true; //?? temp
+  *taken = true; //TODO: replaced this line with the above when service is implemented
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_request.cpp
+++ b/rmw_opendds_cpp/src/rmw_request.cpp
@@ -99,6 +99,7 @@ rmw_take_request(
   }
 
   void * replier = service_info->replier_;
+/*
   if (!replier) {
     RMW_SET_ERROR_MSG("replier handle is null");
     return RMW_RET_ERROR;
@@ -111,7 +112,8 @@ rmw_take_request(
   }
 
   *taken = callbacks->take_request(replier, request_header, ros_request);
-
+*/
+  *taken = true; //?? temp
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_response.cpp
+++ b/rmw_opendds_cpp/src/rmw_response.cpp
@@ -105,7 +105,7 @@ rmw_send_response(
     RMW_SET_ERROR_MSG("service info handle is null");
     return RMW_RET_ERROR;
   }
-/*
+/*  TODO: uncommnet this block when type support is ready and service is properly implemented.
   void * replier = service_info->replier_;
   if (!replier) {
     RMW_SET_ERROR_MSG("replier handle is null");

--- a/rmw_opendds_cpp/src/rmw_response.cpp
+++ b/rmw_opendds_cpp/src/rmw_response.cpp
@@ -105,7 +105,7 @@ rmw_send_response(
     RMW_SET_ERROR_MSG("service info handle is null");
     return RMW_RET_ERROR;
   }
-
+/*
   void * replier = service_info->replier_;
   if (!replier) {
     RMW_SET_ERROR_MSG("replier handle is null");
@@ -119,7 +119,7 @@ rmw_send_response(
   }
 
   callbacks->send_response(replier, request_header, ros_response);
-
+*/
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_serialize.cpp
+++ b/rmw_opendds_cpp/src/rmw_serialize.cpp
@@ -28,7 +28,10 @@ rmw_serialize(
   const rosidl_message_type_support_t * type_support,
   rmw_serialized_message_t * serialized_message)
 {
-  RMW_OPENDDS_EXTRACT_MESSAGE_TYPESUPPORT(type_support, ts, RMW_RET_ERROR)
+  const rosidl_message_type_support_t * ts = rmw_get_message_type_support(type_support);
+  if (!ts) {
+    return NULL;
+  }
 
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(ts->data);
@@ -51,7 +54,10 @@ rmw_deserialize(
   const rosidl_message_type_support_t * type_support,
   void * ros_message)
 {
-  RMW_OPENDDS_EXTRACT_MESSAGE_TYPESUPPORT(type_support, ts, RMW_RET_ERROR)
+  const rosidl_message_type_support_t * ts = rmw_get_message_type_support(type_support);
+  if (!ts) {
+    return NULL;
+  }
 
   const message_type_support_callbacks_t * callbacks =
     static_cast<const message_type_support_callbacks_t *>(ts->data);

--- a/rmw_opendds_cpp/src/rmw_service.cpp
+++ b/rmw_opendds_cpp/src/rmw_service.cpp
@@ -106,12 +106,13 @@ rmw_create_service(
     // error string was set within the function
     goto fail;
   }
-
+/*
+  //?? get_default_publisher_qos or pass DDS::Publisher* to get_datawriter_qos
   if (!get_datawriter_qos(participant, *qos_profile, datawriter_qos)) {
     // error string was set within the function
     goto fail;
   }
-
+*/
   // allocating memory for request topic and response topic strings
   if (!_process_service_name(
       service_name,

--- a/rmw_opendds_cpp/src/rmw_service.cpp
+++ b/rmw_opendds_cpp/src/rmw_service.cpp
@@ -30,6 +30,7 @@
 // This affects code in this file, but there is a similar variable in:
 //   rmw_opendds_shared_cpp/shared_functions.cpp
 // #define DISCOVERY_DEBUG_LOGGING 1
+#include <dds/DCPS/Marked_Default_Qos.h> //?? temp
 
 extern "C"
 {
@@ -49,7 +50,10 @@ rmw_create_service(
     node->implementation_identifier, opendds_identifier,
     return NULL)
 
-  RMW_OPENDDS_EXTRACT_SERVICE_TYPESUPPORT(type_supports, type_support, NULL)
+  const rosidl_service_type_support_t * type_support = rmw_get_service_type_support(type_supports);
+  if (!type_support) {
+    return NULL;
+  }
 
   if (!qos_profile) {
     RMW_SET_ERROR_MSG("qos_profile is null");
@@ -101,18 +105,18 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("service handle is null");
     goto fail;
   }
-
+/*
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
     // error string was set within the function
     goto fail;
   }
-/*
-  //?? get_default_publisher_qos or pass DDS::Publisher* to get_datawriter_qos
+
   if (!get_datawriter_qos(participant, *qos_profile, datawriter_qos)) {
     // error string was set within the function
     goto fail;
   }
 */
+
   // allocating memory for request topic and response topic strings
   if (!_process_service_name(
       service_name,
@@ -122,7 +126,7 @@ rmw_create_service(
   {
     goto fail;
   }
-
+/*
   replier = callbacks->create_replier(
     participant, request_topic_str, response_topic_str,
     &datareader_qos, &datawriter_qos,
@@ -226,7 +230,7 @@ rmw_create_service(
   fprintf(stderr, "Publisher address %p\n", static_cast<void *>(dds_publisher));
   fprintf(stderr, "******\n");
 #endif
-
+*/
   return service;
 fail:
   if (request_topic_str) {

--- a/rmw_opendds_cpp/src/rmw_service.cpp
+++ b/rmw_opendds_cpp/src/rmw_service.cpp
@@ -103,7 +103,8 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("failed to allocate service");
     goto fail;
   }
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement service properly.
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
     // error string was set within the function
     goto fail;
@@ -123,7 +124,8 @@ rmw_create_service(
   {
     goto fail;
   }
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement service properly.
   replier = callbacks->create_replier(
     participant, request_topic_str, response_topic_str,
     &datareader_qos, &datawriter_qos,
@@ -184,10 +186,10 @@ rmw_create_service(
   // Use a placement new to construct the OpenDDSStaticServiceInfo in the preallocated buffer.
   RMW_TRY_PLACEMENT_NEW(service_info, buf, goto fail, OpenDDSStaticServiceInfo, )
   buf = nullptr;  // Only free the service_info pointer; don't need the buf pointer anymore.
-  service_info->replier_ = NULL; //replier;
+  service_info->replier_ = nullptr; //replier;
   service_info->callbacks_ = callbacks;
-  service_info->request_datareader_ = NULL; //request_datareader;
-  service_info->read_condition_ = NULL; //read_condition;
+  service_info->request_datareader_ = nullptr; //request_datareader;
+  service_info->read_condition_ = nullptr; //read_condition;
 
   service->implementation_identifier = opendds_identifier;
   service->data = service_info;
@@ -197,7 +199,8 @@ rmw_create_service(
     goto fail;
   }
   memcpy(const_cast<char *>(service->service_name), service_name, strlen(service_name) + 1);
-/*
+/* //commented out for clearing crashes before type support is ready.
+   //TODO: implement service properly.
   mangled_name =
     request_datareader->get_topicdescription()->get_name();
   node_info->subscriber_listener->add_information(

--- a/rmw_opendds_cpp/src/rmw_service.cpp
+++ b/rmw_opendds_cpp/src/rmw_service.cpp
@@ -30,7 +30,6 @@
 // This affects code in this file, but there is a similar variable in:
 //   rmw_opendds_shared_cpp/shared_functions.cpp
 // #define DISCOVERY_DEBUG_LOGGING 1
-#include <dds/DCPS/Marked_Default_Qos.h> //?? temp
 
 extern "C"
 {
@@ -42,12 +41,11 @@ rmw_create_service(
   const rmw_qos_profile_t * qos_profile)
 {
   if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
+    RMW_SET_ERROR_MSG("node is null");
     return NULL;
   }
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    node handle,
-    node->implementation_identifier, opendds_identifier,
+    node handle, node->implementation_identifier, opendds_identifier,
     return NULL)
 
   const rosidl_service_type_support_t * type_support = rmw_get_service_type_support(type_supports);
@@ -62,12 +60,12 @@ rmw_create_service(
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
   if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
+    RMW_SET_ERROR_MSG("node info is null");
     return NULL;
   }
   auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
   if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
+    RMW_SET_ERROR_MSG("participant is null");
     return NULL;
   }
 
@@ -102,7 +100,7 @@ rmw_create_service(
   // Begin initializing elements.
   service = rmw_service_allocate();
   if (!service) {
-    RMW_SET_ERROR_MSG("service handle is null");
+    RMW_SET_ERROR_MSG("failed to allocate service");
     goto fail;
   }
 /*
@@ -116,7 +114,6 @@ rmw_create_service(
     goto fail;
   }
 */
-
   // allocating memory for request topic and response topic strings
   if (!_process_service_name(
       service_name,
@@ -178,7 +175,7 @@ rmw_create_service(
 
   // update attached publisher
   dds_publisher->set_qos(publisher_qos);
-
+*/
   buf = rmw_allocate(sizeof(OpenDDSStaticServiceInfo));
   if (!buf) {
     RMW_SET_ERROR_MSG("failed to allocate memory");
@@ -187,10 +184,10 @@ rmw_create_service(
   // Use a placement new to construct the OpenDDSStaticServiceInfo in the preallocated buffer.
   RMW_TRY_PLACEMENT_NEW(service_info, buf, goto fail, OpenDDSStaticServiceInfo, )
   buf = nullptr;  // Only free the service_info pointer; don't need the buf pointer anymore.
-  service_info->replier_ = replier;
+  service_info->replier_ = NULL; //replier;
   service_info->callbacks_ = callbacks;
-  service_info->request_datareader_ = request_datareader;
-  service_info->read_condition_ = read_condition;
+  service_info->request_datareader_ = NULL; //request_datareader;
+  service_info->read_condition_ = NULL; //read_condition;
 
   service->implementation_identifier = opendds_identifier;
   service->data = service_info;
@@ -200,7 +197,7 @@ rmw_create_service(
     goto fail;
   }
   memcpy(const_cast<char *>(service->service_name), service_name, strlen(service_name) + 1);
-
+/*
   mangled_name =
     request_datareader->get_topicdescription()->get_name();
   node_info->subscriber_listener->add_information(

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -72,17 +72,17 @@ void clean_subscription(rmw_subscription_t * subscription, DDS::DomainParticipan
       if (info->topic_reader_) {
         if (info->read_condition_) {
           if (info->topic_reader_->delete_readcondition(info->read_condition_) != DDS::RETCODE_OK) {
-            std::cerr << "delete_readcondition failed " << __FILE__ << ":" << __LINE__ << std::endl;
+            RMW_SET_ERROR_MSG("delete_readcondition failed");
           }
           info->read_condition_ = nullptr;
         }
         if (info->dds_subscriber_->delete_datareader(info->topic_reader_) != DDS::RETCODE_OK) {
-          std::cerr << "delete_datareader failed " << __FILE__ << ":" << __LINE__ << std::endl;
+          RMW_SET_ERROR_MSG("delete_datareader failed");
         }
         info->topic_reader_ = nullptr;
       }
       if (participant.delete_subscriber(info->dds_subscriber_) != DDS::RETCODE_OK) {
-        std::cerr << "delete_subscriber failed " << __FILE__ << ":" << __LINE__ << std::endl;
+        RMW_SET_ERROR_MSG("delete_subscriber failed");
       }
       info->dds_subscriber_ = nullptr;
     }

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -253,6 +253,7 @@ rmw_create_subscription(
       throw std::string("failed to create read condition");
     }
 
+    subscriber_info->ignore_local_publications = false;
     subscriber_info->callbacks_ = callbacks;
 
     // update node_info

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -145,7 +145,8 @@ rmw_create_subscription(
   std::string type_name = _create_type_name(callbacks, "msg");
   OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
   if (ts->register_type(participant, type_name.c_str()) != DDS::RETCODE_OK) {
-    throw std::string("failed to register OpenDDS type");
+    RMW_SET_ERROR_MSG("failed to register OpenDDS type");
+    return nullptr;
   }
 
   //type_code = callbacks->get_type_code();

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -78,7 +78,10 @@ rmw_create_subscription(
     node->implementation_identifier, opendds_identifier,
     return NULL)
 
-  RMW_OPENDDS_EXTRACT_MESSAGE_TYPESUPPORT(type_supports, type_support, NULL)
+  const rosidl_message_type_support_t * type_support = rmw_get_message_type_support(type_supports);
+  if (!type_support) {
+    return NULL;
+  }
 
   if (!qos_profile) {
     RMW_SET_ERROR_MSG("qos_profile is null");
@@ -205,12 +208,12 @@ rmw_create_subscription(
   }
   CORBA::string_free(topic_str);
   topic_str = nullptr;
-
+/*
   if (!get_datareader_qos(participant, *qos_profile, datareader_qos)) {
     // error string was set within the function
     goto fail;
   }
-
+*/
   //topic_reader = dds_subscriber->create_datareader(
   //  topic, datareader_qos,
   //  NULL, DDS::STATUS_MASK_NONE);
@@ -218,14 +221,14 @@ rmw_create_subscription(
   //  RMW_SET_ERROR_MSG("failed to create datareader");
   //  goto fail;
   //}
-
+/*
   read_condition = topic_reader->create_readcondition(
     DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
   if (!read_condition) {
     RMW_SET_ERROR_MSG("failed to create read condition");
     goto fail;
   }
-
+*/
   // Allocate memory for the OpenDDSStaticSubscriberInfo object.
   info_buf = rmw_allocate(sizeof(OpenDDSStaticSubscriberInfo));
   if (!info_buf) {
@@ -253,7 +256,7 @@ rmw_create_subscription(
     goto fail;
   }
   memcpy(const_cast<char *>(subscription->topic_name), topic_name, strlen(topic_name) + 1);
-
+/*
   if (!qos_profile->avoid_ros_namespace_conventions) {
     mangled_name =
       topic_reader->get_topicdescription()->get_name();
@@ -275,7 +278,7 @@ rmw_create_subscription(
   fprintf(stderr, "Subscriber address %p\n", static_cast<void *>(dds_subscriber));
   fprintf(stderr, "******\n");
 #endif
-
+*/
   return subscription;
 fail:
   if (topic_str) {

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -47,7 +47,7 @@ take(
     return false;
   }
 
-  OpenDDSStaticSerializedDataDataReader * data_reader =
+  OpenDDSStaticSerializedDataDataReader_var data_reader =
     OpenDDSStaticSerializedDataDataReader::_narrow(dds_data_reader);
   if (!data_reader) {
     RMW_SET_ERROR_MSG("failed to narrow data reader");

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -178,11 +178,12 @@ _take(
     return RMW_RET_ERROR;
   }
   // convert the cdr stream to the message
+/*
   if (*taken && !callbacks->to_message(&cdr_stream, ros_message)) {
     RMW_SET_ERROR_MSG("can't convert cdr stream to ros message");
     return RMW_RET_ERROR;
   }
-
+*/
   // the call to take allocates memory for the serialized message
   // we have to free this here again
   free(cdr_stream.buffer);

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -336,7 +336,7 @@ rmw_take_loaned_message(
   (void) taken;
   (void) allocation;
 
-  RMW_SET_ERROR_MSG("rmw_take_loaned_message not implemented for rmw_connext_cpp");
+  RMW_SET_ERROR_MSG("rmw_take_loaned_message not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 
@@ -354,7 +354,7 @@ rmw_take_loaned_message_with_info(
   (void) message_info;
   (void) allocation;
 
-  RMW_SET_ERROR_MSG("rmw_take_loaned_message_with_info not implemented for rmw_connext_cpp");
+  RMW_SET_ERROR_MSG("rmw_take_loaned_message_with_info not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 
@@ -367,7 +367,7 @@ rmw_return_loaned_message_from_subscription(
   (void) loaned_message;
 
   RMW_SET_ERROR_MSG(
-    "rmw_release_loaned_message not implemented for rmw_connext_cpp");
+    "rmw_return_loaned_message_from_subscription not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -47,33 +47,32 @@ take(
     return false;
   }
 
-  //OpenDDSStaticSerializedDataDataReader * data_reader =
-  //  OpenDDSStaticSerializedDataDataReader::narrow(dds_data_reader);
-  //if (!data_reader) {
-  //  RMW_SET_ERROR_MSG("failed to narrow data reader");
-  //  return false;
-  //}
+  OpenDDSStaticSerializedDataDataReader * data_reader =
+    OpenDDSStaticSerializedDataDataReader::_narrow(dds_data_reader);
+  if (!data_reader) {
+    RMW_SET_ERROR_MSG("failed to narrow data reader");
+    return false;
+  }
 
   OpenDDSStaticSerializedDataSeq dds_messages;
   DDS::SampleInfoSeq sample_infos;
   bool ignore_sample = false;
 
-  DDS::ReturnCode_t status;
-  //DDS::ReturnCode_t status = data_reader->take(
-  //  dds_messages,
-  //  sample_infos,
-  //  1,
-  //  DDS::ANY_SAMPLE_STATE,
-  //  DDS::ANY_VIEW_STATE,
-  //  DDS::ANY_INSTANCE_STATE);
+  DDS::ReturnCode_t status = data_reader->take(
+    dds_messages,
+    sample_infos,
+    1,
+    DDS::ANY_SAMPLE_STATE,
+    DDS::ANY_VIEW_STATE,
+    DDS::ANY_INSTANCE_STATE);
   if (status == DDS::RETCODE_NO_DATA) {
-    //data_reader->return_loan(dds_messages, sample_infos);
+    data_reader->return_loan(dds_messages, sample_infos);
     *taken = false;
     return true;
   }
   if (status != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("take failed");
-    //data_reader->return_loan(dds_messages, sample_infos);
+    data_reader->return_loan(dds_messages, sample_infos);
     return false;
   }
 
@@ -110,7 +109,7 @@ take(
 
     if (cdr_stream->buffer_length > (std::numeric_limits<unsigned int>::max)()) {
       RMW_SET_ERROR_MSG("cdr_stream->buffer_length unexpectedly larger than max unsiged int value");
-      //data_reader->return_loan(dds_messages, sample_infos);
+      data_reader->return_loan(dds_messages, sample_infos);
       *taken = false;
       return false;
     }
@@ -122,7 +121,7 @@ take(
     *taken = false;
   }
 
-  //data_reader->return_loan(dds_messages, sample_infos);
+  data_reader->return_loan(dds_messages, sample_infos);
 
   return status == DDS::RETCODE_OK;
 }
@@ -160,7 +159,7 @@ _take(
     RMW_SET_ERROR_MSG("subscriber info handle is null");
     return RMW_RET_ERROR;
   }
-  DDS::DataReader * topic_reader = subscriber_info->topic_reader_;
+  DDS::DataReader_var topic_reader = subscriber_info->topic_reader_;
   if (!topic_reader) {
     RMW_SET_ERROR_MSG("topic reader handle is null");
     return RMW_RET_ERROR;
@@ -173,10 +172,8 @@ _take(
 
   // fetch the incoming message as cdr stream
   rcutils_uint8_array_t cdr_stream = rcutils_get_zero_initialized_uint8_array();
-  if (!take(
-      topic_reader, subscriber_info->ignore_local_publications, &cdr_stream, taken,
-      sending_publication_handle))
-  {
+  if (!take(topic_reader, subscriber_info->ignore_local_publications,
+            &cdr_stream, taken, sending_publication_handle)) {
     RMW_SET_ERROR_MSG("error occured while taking message");
     return RMW_RET_ERROR;
   }
@@ -262,11 +259,11 @@ _take_serialized_message(
     RMW_SET_ERROR_MSG("subscriber info handle is null");
     return RMW_RET_ERROR;
   }
-  //DDSDataReader * topic_reader = subscriber_info->topic_reader_;
-  //if (!topic_reader) {
-  //  RMW_SET_ERROR_MSG("topic reader handle is null");
-  //  return RMW_RET_ERROR;
-  //}
+  DDS::DataReader * topic_reader = subscriber_info->topic_reader_;
+  if (!topic_reader) {
+    RMW_SET_ERROR_MSG("topic reader handle is null");
+    return RMW_RET_ERROR;
+  }
   const message_type_support_callbacks_t * callbacks = subscriber_info->callbacks_;
   if (!callbacks) {
     RMW_SET_ERROR_MSG("callbacks handle is null");
@@ -274,13 +271,11 @@ _take_serialized_message(
   }
 
   // fetch the incoming message as cdr stream
-  //if (!take(
-  //    topic_reader, subscriber_info->ignore_local_publications, serialized_message, taken,
-  //    sending_publication_handle))
-  //{
-  //  RMW_SET_ERROR_MSG("error occured while taking message");
-  //  return RMW_RET_ERROR;
-  //}
+  if (!take(topic_reader, subscriber_info->ignore_local_publications,
+            serialized_message, taken, sending_publication_handle)) {
+    RMW_SET_ERROR_MSG("error occured while taking message");
+    return RMW_RET_ERROR;
+  }
 
   return RMW_RET_OK;
 }
@@ -308,8 +303,7 @@ rmw_take_serialized_message_with_info(
     return RMW_RET_ERROR;
   }
   DDS::InstanceHandle_t sending_publication_handle;
-  auto ret =
-    _take_serialized_message(subscription, serialized_message, taken, &sending_publication_handle);
+  auto ret = _take_serialized_message(subscription, serialized_message, taken, &sending_publication_handle);
   if (ret != RMW_RET_OK) {
     // Error string is already set.
     return RMW_RET_ERROR;
@@ -335,7 +329,6 @@ rmw_take_loaned_message(
   (void) loaned_message;
   (void) taken;
   (void) allocation;
-
   RMW_SET_ERROR_MSG("rmw_take_loaned_message not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
@@ -353,7 +346,6 @@ rmw_take_loaned_message_with_info(
   (void) taken;
   (void) message_info;
   (void) allocation;
-
   RMW_SET_ERROR_MSG("rmw_take_loaned_message_with_info not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
@@ -365,9 +357,7 @@ rmw_return_loaned_message_from_subscription(
 {
   (void) subscription;
   (void) loaned_message;
-
-  RMW_SET_ERROR_MSG(
-    "rmw_return_loaned_message_from_subscription not implemented for rmw_opendds_cpp");
+  RMW_SET_ERROR_MSG("rmw_return_loaned_message_from_subscription not implemented for rmw_opendds_cpp");
   return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -106,9 +106,8 @@ _create_type_name(
   const message_type_support_callbacks_t * callbacks,
   const std::string & sep)
 {
-  return
-    std::string(callbacks->message_namespace) +
-    "::" + sep + "::dds_::" + callbacks->message_name + "_";
+  //return std::string(callbacks->message_namespace) + "::" + sep + "::dds_::" + callbacks->message_name + "_";
+  return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_"); //?? temp
 }
 
 #endif  // TYPE_SUPPORT_COMMON_HPP_

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -55,6 +55,23 @@
     } \
   }
 
+inline const rosidl_message_type_support_t *
+rmw_get_message_type_support(const rosidl_message_type_support_t * type_support)
+{
+  if (!type_support) {
+    RMW_SET_ERROR_MSG("type support is null");
+    return nullptr;
+  }
+  const rosidl_message_type_support_t * ts =
+    //get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+    get_message_typesupport_handle(type_support, "rosidl_typesupport_c"); //for temporary testing
+  if (!ts) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
+      type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+  }
+  return ts;
+}
+
 #define RMW_OPENDDS_EXTRACT_SERVICE_TYPESUPPORT(TYPE_SUPPORTS, TYPE_SUPPORT, RET_VAL) \
   if (!TYPE_SUPPORTS) { \
     RMW_SET_ERROR_MSG("type supports handle is null"); \

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -35,11 +35,15 @@ rmw_get_message_type_support(const rosidl_message_type_support_t * type_support)
     return nullptr;
   }
   const rosidl_message_type_support_t * ts = get_message_typesupport_handle(
-  //type_support, rosidl_typesupport_opendds_c__identifier);
-    type_support, "rosidl_typesupport_c"); //?? temp
+  /*
+    type_support, rosidl_typesupport_opendds_c__identifier);
+  */
+    type_support, "rosidl_typesupport_c"); //?? to be replaced by the above
   if (!ts) {
-//  ts = get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
-    ts = get_message_typesupport_handle(type_support, "rosidl_typesupport_cpp"); //?? temp
+  /*
+    ts = get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+  */
+    ts = get_message_typesupport_handle(type_support, "rosidl_typesupport_cpp"); //?? to be replaced by the above
     if (!ts) {
       RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
         type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
@@ -56,8 +60,10 @@ rmw_get_service_type_support(const rosidl_service_type_support_t * type_support)
     return nullptr;
   }
   const rosidl_service_type_support_t * ts = get_service_typesupport_handle(
-//  type_support, rosidl_typesupport_opendds_c__identifier);
-    type_support, "rosidl_typesupport_cpp"); //?? temp
+  /*
+    type_support, rosidl_typesupport_opendds_c__identifier);
+  */
+    type_support, "rosidl_typesupport_cpp"); //?? to be replaced by the above
   if (!ts) {
     ts = get_service_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
     if (!ts) {
@@ -76,7 +82,7 @@ _create_type_name(
 /*
   return std::string(callbacks->message_namespace) + "::" + sep + "::dds_::" + callbacks->message_name + "_";
 */
-  return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_"); //?? temp
+  return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_"); //?? to be replaced by the above
 }
 
 #endif  // TYPE_SUPPORT_COMMON_HPP_

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -38,12 +38,14 @@ rmw_get_message_type_support(const rosidl_message_type_support_t * type_support)
   /*
     type_support, rosidl_typesupport_opendds_c__identifier);
   */
-    type_support, "rosidl_typesupport_c"); //?? to be replaced by the above
+    //TODO: replace the following line with the above when type support is ready.
+    type_support, "rosidl_typesupport_c");
   if (!ts) {
   /*
     ts = get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
   */
-    ts = get_message_typesupport_handle(type_support, "rosidl_typesupport_cpp"); //?? to be replaced by the above
+    //TODO: replace the following line with the above when type support is ready.
+    ts = get_message_typesupport_handle(type_support, "rosidl_typesupport_cpp");
     if (!ts) {
       RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
         type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
@@ -63,7 +65,8 @@ rmw_get_service_type_support(const rosidl_service_type_support_t * type_support)
   /*
     type_support, rosidl_typesupport_opendds_c__identifier);
   */
-    type_support, "rosidl_typesupport_cpp"); //?? to be replaced by the above
+    //TODO: replace the following line with the above when type support is ready.
+    type_support, "rosidl_typesupport_cpp");
   if (!ts) {
     ts = get_service_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
     if (!ts) {
@@ -82,7 +85,8 @@ _create_type_name(
 /*
   return std::string(callbacks->message_namespace) + "::" + sep + "::dds_::" + callbacks->message_name + "_";
 */
-  return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_"); //?? to be replaced by the above
+  //TODO: replace the following line with the above when type support is ready.
+  return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_");
 }
 
 #endif  // TYPE_SUPPORT_COMMON_HPP_

--- a/rmw_opendds_cpp/src/type_support_common.hpp
+++ b/rmw_opendds_cpp/src/type_support_common.hpp
@@ -27,34 +27,6 @@
 #include "rosidl_typesupport_opendds_cpp/message_type_support.h"
 #include "rosidl_typesupport_opendds_cpp/service_type_support.h"
 
-#define RMW_OPENDDS_EXTRACT_MESSAGE_TYPESUPPORT(TYPE_SUPPORTS, TYPE_SUPPORT, RET_VAL) \
-  if (!TYPE_SUPPORTS) { \
-    RMW_SET_ERROR_MSG("type supports handle is null"); \
-    return RET_VAL; \
-  } \
-  const rosidl_message_type_support_t * TYPE_SUPPORT = \
-    get_message_typesupport_handle( \
-    TYPE_SUPPORTS, rosidl_typesupport_opendds_c__identifier); \
-  if (!TYPE_SUPPORT) { \
-    TYPE_SUPPORT = get_message_typesupport_handle( \
-      TYPE_SUPPORTS, rosidl_typesupport_opendds_cpp::typesupport_identifier); \
-    if (!TYPE_SUPPORT) { \
-      char __msg[1024]; \
-      snprintf( \
-        __msg, 1024, \
-        "type support handle implementation '%s' (%p) does not match valid type supports " \
-        "('%s' (%p), '%s' (%p))", \
-        TYPE_SUPPORTS->typesupport_identifier, \
-        static_cast<const void *>(TYPE_SUPPORTS->typesupport_identifier), \
-        rosidl_typesupport_opendds_cpp::typesupport_identifier, \
-        static_cast<const void *>(rosidl_typesupport_opendds_cpp::typesupport_identifier), \
-        rosidl_typesupport_opendds_c__identifier, \
-        static_cast<const void *>(rosidl_typesupport_opendds_c__identifier)); \
-      RMW_SET_ERROR_MSG(__msg); \
-      return RET_VAL; \
-    } \
-  }
-
 inline const rosidl_message_type_support_t *
 rmw_get_message_type_support(const rosidl_message_type_support_t * type_support)
 {
@@ -62,51 +34,48 @@ rmw_get_message_type_support(const rosidl_message_type_support_t * type_support)
     RMW_SET_ERROR_MSG("type support is null");
     return nullptr;
   }
-  const rosidl_message_type_support_t * ts =
-    //get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
-    get_message_typesupport_handle(type_support, "rosidl_typesupport_c"); //for temporary testing
+  const rosidl_message_type_support_t * ts = get_message_typesupport_handle(
+  //type_support, rosidl_typesupport_opendds_c__identifier);
+    type_support, "rosidl_typesupport_c"); //?? temp
   if (!ts) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
-      type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+//  ts = get_message_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+    ts = get_message_typesupport_handle(type_support, "rosidl_typesupport_cpp"); //?? temp
+    if (!ts) {
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
+        type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+    }
   }
   return ts;
 }
 
-#define RMW_OPENDDS_EXTRACT_SERVICE_TYPESUPPORT(TYPE_SUPPORTS, TYPE_SUPPORT, RET_VAL) \
-  if (!TYPE_SUPPORTS) { \
-    RMW_SET_ERROR_MSG("type supports handle is null"); \
-    return RET_VAL; \
-  } \
-  const rosidl_service_type_support_t * TYPE_SUPPORT = \
-    get_service_typesupport_handle( \
-    TYPE_SUPPORTS, rosidl_typesupport_opendds_c__identifier); \
-  if (!TYPE_SUPPORT) { \
-    TYPE_SUPPORT = get_service_typesupport_handle( \
-      TYPE_SUPPORTS, rosidl_typesupport_opendds_cpp::typesupport_identifier); \
-    if (!TYPE_SUPPORT) { \
-      char __msg[1024]; \
-      snprintf( \
-        __msg, 1024, \
-        "type support handle implementation '%s' (%p) does not match valid type supports " \
-        "('%s' (%p), '%s' (%p))", \
-        TYPE_SUPPORTS->typesupport_identifier, \
-        static_cast<const void *>(TYPE_SUPPORTS->typesupport_identifier), \
-        rosidl_typesupport_opendds_cpp::typesupport_identifier, \
-        static_cast<const void *>(rosidl_typesupport_opendds_cpp::typesupport_identifier), \
-        rosidl_typesupport_opendds_c__identifier, \
-        static_cast<const void *>(rosidl_typesupport_opendds_c__identifier)); \
-      RMW_SET_ERROR_MSG(__msg); \
-      return RET_VAL; \
-    } \
+inline const rosidl_service_type_support_t *
+rmw_get_service_type_support(const rosidl_service_type_support_t * type_support)
+{
+  if (!type_support) {
+    RMW_SET_ERROR_MSG("type support is null");
+    return nullptr;
   }
-
+  const rosidl_service_type_support_t * ts = get_service_typesupport_handle(
+//  type_support, rosidl_typesupport_opendds_c__identifier);
+    type_support, "rosidl_typesupport_cpp"); //?? temp
+  if (!ts) {
+    ts = get_service_typesupport_handle(type_support, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+    if (!ts) {
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("type support implementation '%s' does not match '%s'",
+        type_support->typesupport_identifier, rosidl_typesupport_opendds_cpp::typesupport_identifier);
+    }
+  }
+  return ts;
+}
 
 inline std::string
 _create_type_name(
   const message_type_support_callbacks_t * callbacks,
   const std::string & sep)
 {
-  //return std::string(callbacks->message_namespace) + "::" + sep + "::dds_::" + callbacks->message_name + "_";
+/*
+  return std::string(callbacks->message_namespace) + "::" + sep + "::dds_::" + callbacks->message_name + "_";
+*/
   return std::string("callbacks->message_namespace::" + sep + "::dds_::callbacks->message_name_"); //?? temp
 }
 

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
@@ -35,7 +35,7 @@ get_datareader_qos(
 RMW_OPENDDS_SHARED_CPP_PUBLIC
 bool
 get_datawriter_qos(
-  DDS::DomainParticipant * participant,
+  DDS::Publisher * publisher,
   const rmw_qos_profile_t & qos_profile,
   DDS::DataWriterQos & datawriter_qos);
 

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
@@ -28,7 +28,7 @@
 RMW_OPENDDS_SHARED_CPP_PUBLIC
 bool
 get_datareader_qos(
-  DDS::DomainParticipant * participant,
+  DDS::Subscriber * subscriber,
   const rmw_qos_profile_t & qos_profile,
   DDS::DataReaderQos & datareader_qos);
 
@@ -112,7 +112,66 @@ template<typename AttributeT>
 void
 dds_qos_to_rmw_qos(
   const AttributeT& dds_qos,
-  rmw_qos_profile_t* qos);
+  rmw_qos_profile_t* qos)
+{
+  switch (dds_qos.history.kind) {
+  case DDS::KEEP_LAST_HISTORY_QOS:
+    qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+    break;
+  case DDS::KEEP_ALL_HISTORY_QOS:
+    qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
+    break;
+  default:
+    qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
+    break;
+  }
+  qos->depth = static_cast<size_t>(dds_qos.history.depth);
 
+  switch (dds_qos.reliability.kind) {
+  case DDS::BEST_EFFORT_RELIABILITY_QOS:
+    qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    break;
+  case DDS::RELIABLE_RELIABILITY_QOS:
+    qos->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    break;
+  default:
+    qos->reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    break;
+  }
+
+  switch (dds_qos.durability.kind) {
+  case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
+    qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    break;
+  case DDS::VOLATILE_DURABILITY_QOS:
+    qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    break;
+  default:
+    qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    break;
+  }
+
+  qos->deadline.sec = dds_qos.deadline.period.sec;
+  qos->deadline.nsec = dds_qos.deadline.period.nanosec;
+
+  //dds_qos_lifespan_to_rmw_qos_lifespan(dds_qos, qos); //?? temp
+
+  switch (dds_qos.liveliness.kind) {
+  case DDS::AUTOMATIC_LIVELINESS_QOS:
+    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    break;
+  case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
+    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
+    break;
+  case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
+    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    break;
+  default:
+    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+    break;
+  }
+  qos->liveliness_lease_duration.sec = dds_qos.liveliness.lease_duration.sec;
+  qos->liveliness_lease_duration.nsec = dds_qos.liveliness.lease_duration.nanosec;
+}
 
 #endif  // RMW_OPENDDS_SHARED_CPP__QOS_HPP_

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/wait.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/wait.hpp
@@ -158,7 +158,7 @@ wait(
       }
     }
   }
-
+/*
   // add a condition for each service
   if (services) {
     for (size_t i = 0; i < services->service_count; ++i) {
@@ -182,7 +182,7 @@ wait(
       }
     }
   }
-
+*/
   // add a condition for each client
   if (clients) {
     for (size_t i = 0; i < clients->client_count; ++i) {
@@ -299,7 +299,7 @@ wait(
       }
     }
   }
-
+/*
   // set service handles to zero for all not triggered conditions
   if (services) {
     for (size_t i = 0; i < services->service_count; ++i) {
@@ -334,7 +334,7 @@ wait(
       }
     }
   }
-
+*/
   // set client handles to zero for all not triggered conditions
   if (clients) {
     for (size_t i = 0; i < clients->client_count; ++i) {

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/wait.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/wait.hpp
@@ -158,7 +158,7 @@ wait(
       }
     }
   }
-/*
+/*  TODO: uncommnet this block when type support is ready and service is properly implemented.
   // add a condition for each service
   if (services) {
     for (size_t i = 0; i < services->service_count; ++i) {
@@ -299,7 +299,7 @@ wait(
       }
     }
   }
-/*
+/*  TODO: uncommnet this block when type support is ready and service is properly implemented.
   // set service handles to zero for all not triggered conditions
   if (services) {
     for (size_t i = 0; i < services->service_count; ++i) {

--- a/rmw_opendds_shared_cpp/src/qos.cpp
+++ b/rmw_opendds_shared_cpp/src/qos.cpp
@@ -35,21 +35,15 @@ get_datareader_qos(
 
 bool
 get_datawriter_qos(
-  DDS::DomainParticipant * participant,
+  DDS::Publisher * publisher,
   const rmw_qos_profile_t & qos_profile,
   DDS::DataWriterQos & datawriter_qos)
 {
-  DDS::ReturnCode_t status; // @todo jwi = participant->get_default_datawriter_qos(datawriter_qos);
-  if (status != DDS::RETCODE_OK) {
+  if (publisher->get_default_datawriter_qos(datawriter_qos) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default datawriter qos");
     return false;
   }
-
-  if (!set_entity_qos_from_profile(qos_profile, datawriter_qos)) {
-    return false;
-  }
-
-  return true;
+  return set_entity_qos_from_profile(qos_profile, datawriter_qos);
 }
 
 template<typename AttributeT>

--- a/rmw_opendds_shared_cpp/src/qos.cpp
+++ b/rmw_opendds_shared_cpp/src/qos.cpp
@@ -16,21 +16,15 @@
 
 bool
 get_datareader_qos(
-  DDS::DomainParticipant * participant,
+  DDS::Subscriber * subscriber,
   const rmw_qos_profile_t & qos_profile,
   DDS::DataReaderQos & datareader_qos)
 {
-  DDS::ReturnCode_t status; // @todo jwi = participant->get_default_datareader_qos(datareader_qos);
-  if (status != DDS::RETCODE_OK) {
+  if (subscriber->get_default_datareader_qos(datareader_qos) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to get default datareader qos");
     return false;
   }
-
-  if (!set_entity_qos_from_profile(qos_profile, datareader_qos)) {
-    return false;
-  }
-
-  return true;
+  return set_entity_qos_from_profile(qos_profile, datareader_qos);
 }
 
 bool
@@ -44,70 +38,4 @@ get_datawriter_qos(
     return false;
   }
   return set_entity_qos_from_profile(qos_profile, datawriter_qos);
-}
-
-template<typename AttributeT>
-void
-dds_qos_to_rmw_qos(
-  const AttributeT& dds_qos,
-  rmw_qos_profile_t* qos)
-{
-  switch (dds_qos.history.kind) {
-  case DDS::KEEP_LAST_HISTORY_QOS:
-    qos->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-    break;
-  case DDS::KEEP_ALL_HISTORY_QOS:
-    qos->history = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
-    break;
-  default:
-    qos->history = RMW_QOS_POLICY_HISTORY_UNKNOWN;
-    break;
-  }
-  qos->depth = static_cast<size_t>(dds_qos.history.depth);
-
-  switch (dds_qos.reliability.kind) {
-  case DDS::BEST_EFFORT_RELIABILITY_QOS:
-    qos->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-    break;
-  case DDS::RELIABLE_RELIABILITY_QOS:
-    qos->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-    break;
-  default:
-    qos->reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
-    break;
-  }
-
-  switch (dds_qos.durability.kind) {
-  case DDS::TRANSIENT_LOCAL_DURABILITY_QOS:
-    qos->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-    break;
-  case DDS::VOLATILE_DURABILITY_QOS:
-    qos->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-    break;
-  default:
-    qos->durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
-    break;
-  }
-
-  qos->deadline.sec = dds_qos.deadline.period.sec;
-  qos->deadline.nsec = dds_qos.deadline.period.nanosec;
-
-  dds_qos_lifespan_to_rmw_qos_lifespan(dds_qos, qos);
-
-  switch (dds_qos.liveliness.kind) {
-  case DDS::AUTOMATIC_LIVELINESS_QOS:
-    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
-    break;
-  case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
-    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE;
-    break;
-  case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
-    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
-    break;
-  default:
-    qos->liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
-    break;
-  }
-  qos->liveliness_lease_duration.sec = dds_qos.liveliness.lease_duration.sec;
-  qos->liveliness_lease_duration.nsec = dds_qos.liveliness.lease_duration.nanosec;
 }


### PR DESCRIPTION
This PR contains the following two parts:
1. Initial implementation of rmw_create_publisher, rmw_publish, publish, rmw_create_subscription, take, and their related structures and functions: OpenDDSStaticPublisherInfo, OpenDDSStaticSubscriberInfo, OpenDDSStaticServiceInfo, get_datareader_qos, get_datawriter_qos, dds_qos_to_rmw_qos, rmw_get_message_type_support, rmw_get_service_type_support, _process_topic_name, _process_service_name, and OpenDDSSubscriberListener. The type support related code is either commented out or replaced with temporary code for further development.

2. Changes mainly for clearing crashes or errors are made in rmw_service, rmw_client, rmw_request, rmw_response, and wait.hpp. Their proper implementation is out of the scope of this PR.