### PR TITLE
rmw_subscription_get_actual_qos

### DIFF
--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -312,7 +312,7 @@ rmw_publisher_get_actual_qos(
     RMW_SET_ERROR_MSG("publisher writer get_qos failed");
     return RMW_RET_ERROR;
   }
-  dds_qos_to_rmw_qos(dds_qos, qos);
+  dds_qos_to_rmw_qos(dds_qos, *qos);
 
   return RMW_RET_OK;
 }

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -337,7 +337,7 @@ rmw_subscription_get_actual_qos(
   RMW_CHECK_FOR_NULL_WITH_MSG(info->topic_reader_, "topic_reader_ is null", return RMW_RET_ERROR);
   DDS::DataReaderQos dds_qos;
   if (info->topic_reader_->get_qos(dds_qos) == DDS::RETCODE_OK) {
-    dds_qos_to_rmw_qos(dds_qos, qos);
+    dds_qos_to_rmw_qos(dds_qos, *qos);
     return RMW_RET_OK;
   } else {
     RMW_SET_ERROR_MSG("subscription can't get data reader qos policies");

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -328,28 +328,21 @@ rmw_subscription_get_actual_qos(
   rmw_qos_profile_t * qos)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(subscription handle,
+    subscription->implementation_identifier, opendds_identifier, return RMW_RET_ERROR)
   RMW_CHECK_ARGUMENT_FOR_NULL(qos, RMW_RET_INVALID_ARGUMENT);
 
-  //auto info = static_cast<ConnextStaticSubscriberInfo *>(subscription->data);
-  //if (!info) {
-  //  RMW_SET_ERROR_MSG("subscription internal data is invalid");
-  //  return RMW_RET_ERROR;
-  //}
-  //DDS::DataReader * data_reader = info->topic_reader_;
-  //if (!data_reader) {
-  //  RMW_SET_ERROR_MSG("subscription internal data reader is invalid");
-  //  return RMW_RET_ERROR;
-  //}
-  //DDS::DataReaderQos dds_qos;
-  //DDS::ReturnCode_t status = data_reader->get_qos(dds_qos);
-  //if (DDS::RETCODE_OK != status) {
-  //  RMW_SET_ERROR_MSG("subscription can't get data reader qos policies");
-  //  return RMW_RET_ERROR;
-  //}
-
-  //dds_qos_to_rmw_qos(dds_qos, qos);
-
-  return RMW_RET_OK;
+  auto info = static_cast<OpenDDSStaticSubscriberInfo *>(subscription->data);
+  RMW_CHECK_FOR_NULL_WITH_MSG(info, "subscriber info is null", return RMW_RET_ERROR);
+  RMW_CHECK_FOR_NULL_WITH_MSG(info->topic_reader_, "topic_reader_ is null", return RMW_RET_ERROR);
+  DDS::DataReaderQos dds_qos;
+  if (info->topic_reader_->get_qos(dds_qos) == DDS::RETCODE_OK) {
+    dds_qos_to_rmw_qos(dds_qos, qos);
+    return RMW_RET_OK;
+  } else {
+    RMW_SET_ERROR_MSG("subscription can't get data reader qos policies");
+  }
+  return RMW_RET_ERROR;
 }
 
 rmw_ret_t

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
@@ -94,18 +94,33 @@ set_entity_qos_from_profile(
 
   // ensure the history depth is at least the requested queue size
   assert(entity_qos.history.depth >= 0);
-  if (
-    entity_qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS &&
+  if (entity_qos.history.kind == DDS::KEEP_LAST_HISTORY_QOS &&
     static_cast<size_t>(entity_qos.history.depth) < qos_profile.depth)
   {
     if (qos_profile.depth > (std::numeric_limits<CORBA::ULong>::max)()) {
-      RMW_SET_ERROR_MSG(
-        "failed to set history depth since the requested queue size exceeds the DDS type");
+      RMW_SET_ERROR_MSG("failed to set history depth since the requested queue size exceeds the DDS type");
       return false;
     }
     entity_qos.history.depth = static_cast<CORBA::ULong>(qos_profile.depth);
   }
   return true;
+}
+
+inline void
+dds_qos_lifespan_to_rmw_qos_lifespan(
+  const DDS::DataWriterQos & dds_qos,
+  rmw_qos_profile_t * qos)
+{
+  qos->lifespan.sec = dds_qos.lifespan.duration.sec;
+  qos->lifespan.nsec = dds_qos.lifespan.duration.nanosec;
+}
+
+inline void
+dds_qos_lifespan_to_rmw_qos_lifespan(
+  const DDS::DataReaderQos &,
+  rmw_qos_profile_t *)
+{
+  // no-op since no lifespan in DataReader
 }
 
 template<typename AttributeT>
@@ -154,7 +169,7 @@ dds_qos_to_rmw_qos(
   qos->deadline.sec = dds_qos.deadline.period.sec;
   qos->deadline.nsec = dds_qos.deadline.period.nanosec;
 
-  //dds_qos_lifespan_to_rmw_qos_lifespan(dds_qos, qos); //?? temp
+  dds_qos_lifespan_to_rmw_qos_lifespan(dds_qos, qos);
 
   switch (dds_qos.liveliness.kind) {
   case DDS::AUTOMATIC_LIVELINESS_QOS:

--- a/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
+++ b/rmw_opendds_shared_cpp/include/rmw_opendds_shared_cpp/qos.hpp
@@ -59,7 +59,6 @@ time_to_rmw(rmw_time_t & rmw, const DDS::Duration_t & dds) {
 inline void
 qos_lifespan_to_rmw(rmw_qos_profile_t & rmw_qos, const DDS::DataWriterQos & dds_qos) {
   time_to_rmw(rmw_qos.lifespan, dds_qos.lifespan.duration);
-  std::cerr << "\nlifespan(" << rmw_qos.lifespan.sec << ',' << rmw_qos.lifespan.nsec << ")";
 }
 
 inline void

--- a/rmw_opendds_shared_cpp/src/qos.cpp
+++ b/rmw_opendds_shared_cpp/src/qos.cpp
@@ -24,7 +24,7 @@ get_datareader_qos(
     RMW_SET_ERROR_MSG("failed to get default datareader qos");
     return false;
   }
-  return set_entity_qos_from_profile(qos_profile, datareader_qos);
+  return rmw_qos_to_dds_qos(qos_profile, datareader_qos);
 }
 
 bool
@@ -37,5 +37,5 @@ get_datawriter_qos(
     RMW_SET_ERROR_MSG("failed to get default datawriter qos");
     return false;
   }
-  return set_entity_qos_from_profile(qos_profile, datawriter_qos);
+  return rmw_qos_to_dds_qos(qos_profile, datawriter_qos);
 }


### PR DESCRIPTION
Current MinimalSubscriber usually misses the first 3 messages.
This PR contains the implementation of rmw_subscription_get_actual_qos(). The code runs ok and the qos is set to DDS::RELIABLE_RELIABILITY_QOS. However, it didn't solve the MinimalSubscriber problem.