### PR TITLE
rmw_destroy_subscription and take memcpy

### DIFF
--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -62,38 +62,54 @@ rmw_fini_subscription_allocation(rmw_subscription_allocation_t * allocation)
   return RMW_RET_ERROR;
 }
 
-void clean_subscription(rmw_subscription_t * subscription, DDS::DomainParticipant& participant){
+rmw_ret_t
+clean_subscription(rmw_subscription_t * subscription, OpenDDSNodeInfo & node_info, DDS::DomainParticipant & participant)
+{
+  auto ret = RMW_RET_OK;
   if (!subscription) {
-    return;
+    return ret;
   }
+
   auto info = static_cast<OpenDDSStaticSubscriberInfo*>(subscription->data);
   if (info) {
     if (info->dds_subscriber_) {
+      node_info.subscriber_listener->remove_information(
+        info->dds_subscriber_->get_instance_handle(), EntityType::Subscriber);
+      node_info.subscriber_listener->trigger_graph_guard_condition();
       if (info->topic_reader_) {
         if (info->read_condition_) {
           if (info->topic_reader_->delete_readcondition(info->read_condition_) != DDS::RETCODE_OK) {
             RMW_SET_ERROR_MSG("delete_readcondition failed");
+            ret = RMW_RET_ERROR;
           }
           info->read_condition_ = nullptr;
         }
         if (info->dds_subscriber_->delete_datareader(info->topic_reader_) != DDS::RETCODE_OK) {
           RMW_SET_ERROR_MSG("delete_datareader failed");
+          ret = RMW_RET_ERROR;
         }
         info->topic_reader_ = nullptr;
+      } else if (info->read_condition_) {
+        RMW_SET_ERROR_MSG("cannot delete readcondition because the datareader is null");
+        ret = RMW_RET_ERROR;
       }
       if (participant.delete_subscriber(info->dds_subscriber_) != DDS::RETCODE_OK) {
         RMW_SET_ERROR_MSG("delete_subscriber failed");
+        ret = RMW_RET_ERROR;
       }
       info->dds_subscriber_ = nullptr;
+    } else if (info->topic_reader_) {
+      RMW_SET_ERROR_MSG("cannot delete datareader because the subscriber is null");
+      ret = RMW_RET_ERROR;
     }
     if (info->listener_) {
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        info->listener_->~OpenDDSSubscriberListener(), OpenDDSSubscriberListener)
+      RMW_TRY_DESTRUCTOR(info->listener_->~OpenDDSSubscriberListener(),
+        OpenDDSSubscriberListener, ret = RMW_RET_ERROR)
       rmw_free(info->listener_);
       info->listener_ = nullptr;
     }
-    RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-      info->~OpenDDSStaticSubscriberInfo(), OpenDDSStaticSubscriberInfo)
+    RMW_TRY_DESTRUCTOR(info->~OpenDDSStaticSubscriberInfo(),
+      OpenDDSStaticSubscriberInfo, ret = RMW_RET_ERROR)
     rmw_free(info);
     subscription->data = nullptr;
   }
@@ -101,6 +117,7 @@ void clean_subscription(rmw_subscription_t * subscription, DDS::DomainParticipan
     rmw_free(const_cast<char *>(subscription->topic_name));
   }
   rmw_subscription_free(subscription);
+  return ret;
 }
 
 rmw_subscription_t *
@@ -111,61 +128,30 @@ rmw_create_subscription(
   const rmw_qos_profile_t * qos_profile,
   const rmw_subscription_options_t* subscription_options)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node is null");
-    return nullptr;
-  }
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    node handle, node->implementation_identifier, opendds_identifier,
-    return nullptr)
+  RMW_CHECK_FOR_NULL_WITH_MSG(node, "node is null", return nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node, node->implementation_identifier, opendds_identifier, return nullptr)
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info is null");
-    return nullptr;
-  }
-
-  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
-  if (!participant) {
-    RMW_SET_ERROR_MSG("participant is null");
-    return nullptr;
-  }
+  RMW_CHECK_FOR_NULL_WITH_MSG(node_info, "node_info is null", return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(node_info->participant.in(), "participant is null", return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(node_info->subscriber_listener, "subscriber_listener is null", return nullptr);
 
   // message type support
   const rosidl_message_type_support_t * type_support = rmw_get_message_type_support(type_supports);
   if (!type_support) {
     return nullptr;
   }
-  const message_type_support_callbacks_t * callbacks =
-    static_cast<const message_type_support_callbacks_t *>(type_support->data);
+  auto callbacks = static_cast<const message_type_support_callbacks_t*>(type_support->data);
   if (!callbacks) {
     RMW_SET_ERROR_MSG("callbacks handle is null");
     return nullptr;
   }
   std::string type_name = _create_type_name(callbacks, "msg");
   OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
-  if (ts->register_type(participant, type_name.c_str()) != DDS::RETCODE_OK) {
+  if (ts->register_type(node_info->participant.in(), type_name.c_str()) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to register OpenDDS type");
     return nullptr;
   }
-
-  //type_code = callbacks->get_type_code();
-  //if (!type_code) {
-  //  RMW_SET_ERROR_MSG("failed to fetch type code\n");
-  //  goto fail;
-  //}
-  // This is a non-standard RTI OpenDDS function
-  // It allows to register an external type to a static data writer
-  // In this case, we register the custom message type to a data writer,
-  // which only publishes DDS_Octets
-  // The purpose of this is to send only raw data DDS_Octets over the wire,
-  // advertise the topic however with a type of the message, e.g. std_msgs::msg::dds_::String
-  //status = OpenDDSStaticSerializedDataSupport_register_external_type(
-  //  participant, type_name.c_str(), type_code);
-  //if (status != DDS::RETCODE_OK) {
-  //  RMW_SET_ERROR_MSG("failed to register external type");
-  //  goto fail;
-  //}
 
   std::string topic_str = get_topic_str(topic_name, qos_profile->avoid_ros_namespace_conventions);
   if (topic_str.empty()) {
@@ -178,12 +164,12 @@ rmw_create_subscription(
   }
 
   // find or create DDS::Topic
-  DDS::TopicDescription_var topic_description = participant->lookup_topicdescription(topic_str.c_str());
-  DDS::Topic_var topic = topic_description ?
-    participant->find_topic(topic_str.c_str(), DDS::Duration_t{0, 0}) :
-    participant->create_topic(topic_str.c_str(), type_name.c_str(), TOPIC_QOS_DEFAULT, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
+  DDS::TopicDescription_var topic_des = node_info->participant->lookup_topicdescription(topic_str.c_str());
+  DDS::Topic_var topic = topic_des ?
+    node_info->participant->find_topic(topic_str.c_str(), DDS::Duration_t{0, 0}) :
+    node_info->participant->create_topic(topic_str.c_str(), type_name.c_str(), TOPIC_QOS_DEFAULT, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
   if (!topic) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("failed to %s topic", (topic_description ? "find" : "create"));
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("failed to %s topic", (topic_des ? "find" : "create"));
     return nullptr;
   }
 
@@ -226,7 +212,7 @@ rmw_create_subscription(
     buf = nullptr;
 
     // create DDS::Subscriber
-    subscriber_info->dds_subscriber_ = participant->create_subscriber(
+    subscriber_info->dds_subscriber_ = node_info->participant->create_subscriber(
       SUBSCRIBER_QOS_DEFAULT, subscriber_info->listener_, DDS::SUBSCRIPTION_MATCHED_STATUS);
     if (!subscriber_info->dds_subscriber_) {
       throw std::string("failed to create subscriber");
@@ -268,7 +254,7 @@ rmw_create_subscription(
       }
     }
     node_info->subscriber_listener->add_information(
-      participant->get_instance_handle(),
+      node_info->participant->get_instance_handle(),
       subscriber_info->dds_subscriber_->get_instance_handle(),
       mangled_name, type_name, EntityType::Subscriber);
     node_info->subscriber_listener->trigger_graph_guard_condition();
@@ -280,8 +266,7 @@ rmw_create_subscription(
   } catch (...) {
     RMW_SET_ERROR_MSG("rmw_create_subscription failed");
   }
-
-  clean_subscription(subscription, *participant);
+  clean_subscription(subscription, *node_info, *node_info->participant);
   if (buf) {
     rmw_free(buf);
   }
@@ -344,83 +329,19 @@ rmw_subscription_get_actual_qos(
 rmw_ret_t
 rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 {
-  if (!node) {
-    RMW_SET_ERROR_MSG("node handle is null");
-    return RMW_RET_ERROR;
-  }
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    node handle,
-    node->implementation_identifier, opendds_identifier,
-    return RMW_RET_ERROR)
-
-  if (!subscription) {
-    RMW_SET_ERROR_MSG("subscription handle is null");
-    return RMW_RET_ERROR;
-  }
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
-    subscription handle,
-    subscription->implementation_identifier, opendds_identifier,
-    return RMW_RET_ERROR)
+  RMW_CHECK_FOR_NULL_WITH_MSG(node, "node is null", return RMW_RET_ERROR);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node, node->implementation_identifier,
+    opendds_identifier, return RMW_RET_ERROR)
 
   auto node_info = static_cast<OpenDDSNodeInfo *>(node->data);
-  if (!node_info) {
-    RMW_SET_ERROR_MSG("node info handle is null");
-    return RMW_RET_ERROR;
-  }
-  auto participant = static_cast<DDS::DomainParticipant *>(node_info->participant);
-  if (!participant) {
-    RMW_SET_ERROR_MSG("participant handle is null");
-    return RMW_RET_ERROR;
-  }
-  // TODO(wjwwood): need to figure out when to unregister types with the participant.
-  auto result = RMW_RET_OK;
-  OpenDDSStaticSubscriberInfo * subscriber_info =
-    static_cast<OpenDDSStaticSubscriberInfo *>(subscription->data);
-  if (subscriber_info) {
-    node_info->subscriber_listener->remove_information(
-      subscriber_info->dds_subscriber_->get_instance_handle(), EntityType::Subscriber);
-    node_info->subscriber_listener->trigger_graph_guard_condition();
-    auto dds_subscriber = subscriber_info->dds_subscriber_;
-    if (dds_subscriber) {
-      auto topic_reader = subscriber_info->topic_reader_;
-      if (topic_reader) {
-        auto read_condition = subscriber_info->read_condition_;
-        if (read_condition) {
-          if (topic_reader->delete_readcondition(read_condition) != DDS::RETCODE_OK) {
-            RMW_SET_ERROR_MSG("failed to delete readcondition");
-            result = RMW_RET_ERROR;
-          }
-          subscriber_info->read_condition_ = nullptr;
-        }
-        if (dds_subscriber->delete_datareader(topic_reader) != DDS::RETCODE_OK) {
-          RMW_SET_ERROR_MSG("failed to delete datareader");
-          result = RMW_RET_ERROR;
-        }
-        subscriber_info->topic_reader_ = nullptr;
-      } else if (subscriber_info->read_condition_) {
-        RMW_SET_ERROR_MSG("cannot delete readcondition because the datareader is null");
-        result = RMW_RET_ERROR;
-      }
-      if (participant->delete_subscriber(dds_subscriber) != DDS::RETCODE_OK) {
-        RMW_SET_ERROR_MSG("failed to delete subscriber");
-        result = RMW_RET_ERROR;
-      }
-      subscriber_info->dds_subscriber_ = nullptr;
-    } else if (subscriber_info->topic_reader_) {
-      RMW_SET_ERROR_MSG("cannot delete datareader because the subscriber is null");
-      result = RMW_RET_ERROR;
-    }
-    RMW_TRY_DESTRUCTOR(
-      subscriber_info->~OpenDDSStaticSubscriberInfo(),
-      OpenDDSStaticSubscriberInfo, result = RMW_RET_ERROR)
-    rmw_free(subscriber_info);
-    subscription->data = nullptr;
-  }
-  if (subscription->topic_name) {
-    rmw_free(const_cast<char *>(subscription->topic_name));
-  }
-  rmw_subscription_free(subscription);
+  RMW_CHECK_FOR_NULL_WITH_MSG(node_info, "node_info is null", return RMW_RET_ERROR);
+  RMW_CHECK_FOR_NULL_WITH_MSG(node_info->participant.in(), "participant is null", return RMW_RET_ERROR);
 
-  return result;
+  RMW_CHECK_FOR_NULL_WITH_MSG(subscription, "subscription is null", return RMW_RET_ERROR);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(subscription, subscription->implementation_identifier,
+    opendds_identifier, return RMW_RET_ERROR)
+
+  // TODO(wjwwood): need to figure out when to unregister types with the participant.
+  return clean_subscription(subscription, *node_info, *node_info->participant);
 }
 }  // extern "C"

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -164,12 +164,12 @@ rmw_create_subscription(
   }
 
   // find or create DDS::Topic
-  DDS::TopicDescription_var topic_des = node_info->participant->lookup_topicdescription(topic_str.c_str());
-  DDS::Topic_var topic = topic_des ?
+  DDS::TopicDescription_var topic_description = node_info->participant->lookup_topicdescription(topic_str.c_str());
+  DDS::Topic_var topic = topic_description ?
     node_info->participant->find_topic(topic_str.c_str(), DDS::Duration_t{0, 0}) :
     node_info->participant->create_topic(topic_str.c_str(), type_name.c_str(), TOPIC_QOS_DEFAULT, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
   if (!topic) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("failed to %s topic", (topic_des ? "find" : "create"));
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("failed to %s topic", (topic_description ? "find" : "create"));
     return nullptr;
   }
 

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -148,7 +148,7 @@ rmw_create_subscription(
   }
   std::string type_name = _create_type_name(callbacks, "msg");
   OpenDDSStaticSerializedDataTypeSupport_var ts = new OpenDDSStaticSerializedDataTypeSupportImpl();
-  if (ts->register_type(node_info->participant.in(), type_name.c_str()) != DDS::RETCODE_OK) {
+  if (ts->register_type(node_info->participant, type_name.c_str()) != DDS::RETCODE_OK) {
     RMW_SET_ERROR_MSG("failed to register OpenDDS type");
     return nullptr;
   }

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -61,13 +61,13 @@ take(
   if (DDS::RETCODE_OK == status) {
     DDS::SampleInfo & info = sample_infos[0];
     if (info.valid_data) {
-      if (dds_messages[0].serialized_data.length() <= (std::numeric_limits<unsigned int>::max)()) {
-        cdr_stream->buffer_length = dds_messages[0].serialized_data.length();
-        cdr_stream->buffer_capacity = cdr_stream->buffer_length;
-        const size_t buf_size = cdr_stream->buffer_length * sizeof(uint8_t);
-        cdr_stream->buffer = (uint8_t *)cdr_stream->allocator.allocate(buf_size, cdr_stream->allocator.state);
+      const size_t length = dds_messages[0].serialized_data.length();
+      if (length <= (std::numeric_limits<unsigned int>::max)()) {
+        cdr_stream->buffer_length = length;
+        cdr_stream->buffer_capacity = length;
+        cdr_stream->buffer = (uint8_t *)cdr_stream->allocator.allocate(length, cdr_stream->allocator.state);
         if (cdr_stream->buffer) {
-          std::memcpy(cdr_stream->buffer, dds_messages[0].serialized_data.get_buffer(), buf_size);
+          std::memcpy(cdr_stream->buffer, dds_messages[0].serialized_data.get_buffer(), length);
           *taken = true;
 
           if (message_info) {

--- a/rmw_opendds_cpp/src/rmw_take.cpp
+++ b/rmw_opendds_cpp/src/rmw_take.cpp
@@ -61,10 +61,11 @@ take(
   if (DDS::RETCODE_OK == status) {
     DDS::SampleInfo & info = sample_infos[0];
     if (info.valid_data) {
-      cdr_stream->buffer_length = dds_messages[0].serialized_data.length();
-      if (cdr_stream->buffer_length <= (std::numeric_limits<unsigned int>::max)()) {
-        size_t buf_size = cdr_stream->buffer_length * sizeof(uint8_t);
-        cdr_stream->buffer = reinterpret_cast<uint8_t *>(malloc(buf_size));
+      if (dds_messages[0].serialized_data.length() <= (std::numeric_limits<unsigned int>::max)()) {
+        cdr_stream->buffer_length = dds_messages[0].serialized_data.length();
+        cdr_stream->buffer_capacity = cdr_stream->buffer_length;
+        const size_t buf_size = cdr_stream->buffer_length * sizeof(uint8_t);
+        cdr_stream->buffer = (uint8_t *)cdr_stream->allocator.allocate(buf_size, cdr_stream->allocator.state);
         if (cdr_stream->buffer) {
           std::memcpy(cdr_stream->buffer, dds_messages[0].serialized_data.get_buffer(), buf_size);
           *taken = true;
@@ -79,7 +80,7 @@ take(
           RMW_SET_ERROR_MSG("failed to allocate memory for uint8 array");
         }
       } else {
-        RMW_SET_ERROR_MSG("cdr_stream->buffer_length > max unsigned int");
+        RMW_SET_ERROR_MSG("dds message length > max unsigned int");
       }
     }
   } else if (DDS::RETCODE_NO_DATA != status) {
@@ -98,7 +99,7 @@ take(
   rmw_message_info_t * message_info)
 {
   RMW_CHECK_FOR_NULL_WITH_MSG(ros_message, "ros_message is null", return RMW_RET_ERROR);
-  rcutils_uint8_array_t cdr_stream = rcutils_get_zero_initialized_uint8_array();
+  rcutils_uint8_array_t cdr_stream = {nullptr, 0lu, 0lu, rcutils_get_default_allocator()};
   rmw_ret_t ret = take(subscription, &cdr_stream, taken, message_info);
   if (RMW_RET_OK == ret) {
     if (*taken) {
@@ -108,7 +109,7 @@ take(
         RMW_SET_ERROR_MSG("can't convert cdr stream to ros message");
         ret = RMW_RET_ERROR;
       }
-      free(cdr_stream.buffer);
+      cdr_stream.allocator.deallocate(cdr_stream.buffer, cdr_stream.allocator.state);
     }
   }
   return ret;


### PR DESCRIPTION
This PR contains:

1. properly and consistently destroy subscription.
Still need to figure out when to unregister type.

2. memcpy replaced byte-by-byte copy in take(). default allocator replaced malloc and free.  Not using rcutils_uint8_array_init() and rcutils_uint8_array_fini() due to a bug in rcutils_uint8_array_init(): buffer_length is 0 even after allocation.
https://github.com/ros2/rcutils/blob/master/src/uint8_array.c