### PR TITLE
Interop fixes pub/sub

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ This project contains several ROS2 packages:
   - `rosidl_typesupport_opendds_c`: Responsible for generating OpenDDS C headers based on the OMG IDLs produced by ROS2 preprocessors.
   - `rosidl_typesupport_opendds_cpp`: Responsible for generating OpenDDS C++ headers based on the OMG IDLs produced by ROS2 preprocessors.
 
-These packages are built using ROS2's `Colcon` and `Ament` build tools. `rosidl_typesupport_c` and `rosidl_typesupport_cpp` are almost identical, but must be provided as separate packages in order to satisfy the build-time requirements of the ROS2 demo projects.
+These packages are built using ROS2's `Colcon` build tool. `rosidl_typesupport_c` and `rosidl_typesupport_cpp` are almost identical, but must be provided as separate packages in order to satisfy the build-time requirements of the ROS2 demo projects.
 
 ## Usage
 See https://github.com/oci-labs/rmw_build/blob/master/README.md for details on how to build and run this repo.

--- a/rmw_opendds_cpp/resources/opendds_static_serialized_data.idl
+++ b/rmw_opendds_cpp/resources/opendds_static_serialized_data.idl
@@ -1,10 +1,4 @@
 #include <dds/DdsDcpsCore.idl>
-
-const long KEY_HASH_LENGTH_16 = 16;
-typedef octet OctetArray16[KEY_HASH_LENGTH_16]; 
-
 @topic struct OpenDDSStaticSerializedData {
-  @key OctetArray16       key_hash;
-  DDS::OctetSeq  serialized_key;
   DDS::OctetSeq  serialized_data;
 };

--- a/rmw_opendds_cpp/src/rmw_publish.cpp
+++ b/rmw_opendds_cpp/src/rmw_publish.cpp
@@ -26,19 +26,6 @@
 
 #include <ace/Message_Block.h>
 
-bool set_key(OpenDDSStaticSerializedData & instance, DDS::DataWriter * dds_data_writer) {
-  OpenDDS::DCPS::DataWriterImpl* dwImpl = dynamic_cast<OpenDDS::DCPS::DataWriterImpl*>(dds_data_writer);
-  if (!dwImpl) {
-    RMW_SET_ERROR_MSG("failed to cast dds_data_writer to DataWriterImpl");
-    return false;
-  }
-  OpenDDS::DCPS::RepoId id = dwImpl->get_publication_id();
-  std::memcpy(instance.key_hash, &id, KEY_HASH_LENGTH_16);
-  instance.serialized_key.length(KEY_HASH_LENGTH_16);
-  std::memcpy(instance.serialized_key.get_buffer(), &id, KEY_HASH_LENGTH_16);
-  return true;
-}
-
 bool
 publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_stream)
 {
@@ -54,9 +41,6 @@ publish(DDS::DataWriter * dds_data_writer, const rcutils_uint8_array_t * cdr_str
   }
 
   OpenDDSStaticSerializedData instance;
-  if (!set_key(instance, dds_data_writer)) {
-    return false;
-  }
   instance.serialized_data.length(static_cast<CORBA::ULong>(cdr_stream->buffer_length));
   std::memcpy(instance.serialized_data.get_buffer(), cdr_stream->buffer, cdr_stream->buffer_length);
 

--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -32,6 +32,7 @@
 // include patched generated code from the build folder
 //#include "opendds_static_serialized_dataTypeSupportC.h"
 #include "opendds_static_serialized_dataTypeSupportImpl.h"
+#include "dds/DCPS/DataWriterImpl_T.h"
 
 // Uncomment this to get extra console output about discovery.
 // This affects code in this file, but there is a similar variable in:
@@ -211,6 +212,10 @@ rmw_create_publisher(
     if (!publisher_info->topic_writer_) {
       throw std::string("failed to create datawriter");
     }
+
+    OpenDDS::DCPS::DataWriterImpl_T<OpenDDSStaticSerializedData> * trt = dynamic_cast<OpenDDS::DCPS::DataWriterImpl_T<OpenDDSStaticSerializedData>*>(publisher_info->topic_writer_.in());
+
+    trt->set_marshal_skip_serialize(true);
 
     // set remaining OpenDDSStaticPublisherInfo members
     publisher_info->callbacks_ = callbacks;

--- a/rmw_opendds_cpp/src/rmw_subscription.cpp
+++ b/rmw_opendds_cpp/src/rmw_subscription.cpp
@@ -37,6 +37,7 @@
 // #define DISCOVERY_DEBUG_LOGGING 1
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/DomainParticipantImpl.h>
+#include "dds/DCPS/DataReaderImpl_T.h"
 
 extern "C"
 {
@@ -232,6 +233,10 @@ rmw_create_subscription(
     if (!subscriber_info->topic_reader_) {
       throw std::string("failed to create datareader");
     }
+
+    OpenDDS::DCPS::DataReaderImpl_T<OpenDDSStaticSerializedData> * trt = dynamic_cast<OpenDDS::DCPS::DataReaderImpl_T<OpenDDSStaticSerializedData>*>(subscriber_info->topic_reader_.in());
+
+    trt->set_marshal_skip_serialize(true);
 
     // create read_condition
     subscriber_info->read_condition_ = subscriber_info->topic_reader_->create_readcondition(


### PR DESCRIPTION
It's been observed that other DDS/RTPS RMW implementations are using 20 bytes to transmit our base test while our OpenDDS RMW is using 64 bytes. At least one part of the interop issues are to match the serialization for user payload between OpenDDS RMW and FastRTPS/Cyclone. 