### PR TITLE
Use OpenDDS 3.15 tagged docker image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   timeoutInMinutes: 90
   pool:
     vmImage: 'ubuntu-20.04'
-  container: objectcomputing/opendds_ros2:latest
+  container: objectcomputing/opendds_ros2:DDS-3.15
   steps:
   - script: |
       printenv


### PR DESCRIPTION
# Description

This fixes the CI build so that it uses a fixed version of OpenDDS (3.15). This avoids changes over time of the OpenDDS master branch that may be incomatible.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] tested in CI
- [x] tested locally

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing system tests pass locally with my changes (when applicable)
- [x] Any dependent changes have been merged and published in downstream modules