### PR TITLE
non-xtypes interop

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: filesystem check
   - script: |
       cd $(Agent.BuildDirectory)/s
-      git clone https://github.com/oci-labs/rosidl_typesupport_opendds
+      git clone --branch opendds_3.16 https://github.com/oci-labs/rosidl_typesupport_opendds
     displayName: clone rosidl_typesupport_opendds
   - script: |
         cd $(Agent.BuildDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: filesystem check
   - script: |
       cd $(Agent.BuildDirectory)/s
-      git clone --branch opendds_3.16 https://github.com/oci-labs/rosidl_typesupport_opendds
+      git clone --branch opendds_3.16 https://github.com/adamsj-oci/rosidl_typesupport_opendds.git
     displayName: clone rosidl_typesupport_opendds
   - script: |
         cd $(Agent.BuildDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: filesystem check
   - script: |
       cd $(Agent.BuildDirectory)/s
-      git clone --branch opendds_3.16 https://github.com/adamsj-oci/rosidl_typesupport_opendds.git
+      git clone https://github.com/oci-labs/rosidl_typesupport_opendds
     displayName: clone rosidl_typesupport_opendds
   - script: |
         cd $(Agent.BuildDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
   timeoutInMinutes: 90
   pool:
     vmImage: 'ubuntu-20.04'
-  container: objectcomputing/opendds_ros2:DDS-3.15
+  container: objectcomputing/opendds_ros2:latest
   steps:
   - script: |
       printenv

--- a/rmw_opendds_cpp/src/rmw_publisher.cpp
+++ b/rmw_opendds_cpp/src/rmw_publisher.cpp
@@ -207,6 +207,8 @@ rmw_create_publisher(
     if (!get_datawriter_qos(publisher_info->dds_publisher_.in(), *qos_policies, dw_qos)) {
       throw std::string("get_datawriter_qos failed");
     }
+    dw_qos.representation.value.length(1);
+    dw_qos.representation.value[0] = DDS::XCDR_DATA_REPRESENTATION;
     publisher_info->topic_writer_ = publisher_info->dds_publisher_->create_datawriter(
       topic, dw_qos, NULL, OpenDDS::DCPS::NO_STATUS_MASK);
     if (!publisher_info->topic_writer_) {

--- a/rmw_opendds_shared_cpp/src/node.cpp
+++ b/rmw_opendds_shared_cpp/src/node.cpp
@@ -32,6 +32,7 @@
 #include <dds/DCPS/transport/framework/TransportConfig.h>
 #include <dds/DCPS/transport/framework/TransportInst.h>
 #include <dds/DCPS/transport/framework/TransportExceptions.h>
+#include <dds/DCPS/RTPS/RtpsDiscovery.h>
 #ifdef OPENDDS_SECURITY
 #include <dds/DCPS/security/framework/Properties.h>
 #endif
@@ -240,6 +241,10 @@ create_node(
     RMW_TRY_PLACEMENT_NEW(info, buf, throw 1, OpenDDSNodeInfo,)
     node->data = info;
     buf = nullptr;
+
+    OpenDDS::DCPS::Discovery_rch disco = TheServiceParticipant->get_discovery(domain_id);
+    OpenDDS::RTPS::RtpsDiscovery_rch rtps_disco = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disco);
+    rtps_disco->use_xtypes(false);
 
     info->participant = dpf->create_participant(static_cast<DDS::DomainId_t>(domain_id), qos, 0, 0);
     if (!info->participant) {


### PR DESCRIPTION
# Description

This fix allows RMW OpenDDS to work with the Foxy version of FastRTPS by disabling xtypes for discovery. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] test on laptop with FastRTPS and OpenDDS
- [x] CI's test_communication tests interop

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing system tests pass locally with my changes (when applicable)
- [x] Any dependent changes have been merged and published in downstream modules