### PR TITLE
Use _var to fix possible leaks

### DIFF
--- a/rmw_opendds_cpp/src/DDSClient.cpp
+++ b/rmw_opendds_cpp/src/DDSClient.cpp
@@ -43,7 +43,7 @@ bool DDSClient::take(rmw_service_info_t * request_header, void * ros_reply) cons
 
 void DDSClient::add_to(OpenDDSNode * dds_node)
 {
-  DDS::TopicDescription_ptr rtd = reader_->get_topicdescription();
+  DDS::TopicDescription_var rtd = reader_->get_topicdescription();
   if (!rtd) {
     throw std::runtime_error("get_topicdescription failed");
   }
@@ -54,7 +54,7 @@ void DDSClient::add_to(OpenDDSNode * dds_node)
   }
   dds_node->add_sub(reader_->get_instance_handle(), name.in(), type_name.in()); //?? double-check
 
-  DDS::Topic_ptr wt = writer_->get_topic();
+  DDS::Topic_var wt = writer_->get_topic();
   if (!wt) {
     throw std::runtime_error("writer->get_topic failed");
   }

--- a/rmw_opendds_cpp/src/DDSServer.cpp
+++ b/rmw_opendds_cpp/src/DDSServer.cpp
@@ -43,7 +43,7 @@ bool DDSServer::send(const rmw_request_id_t * request_header, const void * ros_r
 
 void DDSServer::add_to(OpenDDSNode * dds_node)
 {
-  DDS::TopicDescription_ptr rtd = reader_->get_topicdescription();
+  DDS::TopicDescription_var rtd = reader_->get_topicdescription();
   if (!rtd) {
     throw std::runtime_error("get_topicdescription failed");
   }
@@ -54,7 +54,7 @@ void DDSServer::add_to(OpenDDSNode * dds_node)
   }
   dds_node->add_sub(reader_->get_instance_handle(), name.in(), type_name.in());
 
-  DDS::Topic_ptr wt = writer_->get_topic();
+  DDS::Topic_var wt = writer_->get_topic();
   if (!wt) {
     throw std::runtime_error("writer->get_topic failed");
   }

--- a/rmw_opendds_cpp/src/OpenDDSNode.cpp
+++ b/rmw_opendds_cpp/src/OpenDDSNode.cpp
@@ -373,12 +373,12 @@ OpenDDSNode::OpenDDSNode(rmw_context_t & context, const char * name, const char 
       throw std::runtime_error("configureTransport failed");
     }
 
-    DDS::Subscriber_ptr sub = dp_->get_builtin_subscriber();
+    DDS::Subscriber_var sub = dp_->get_builtin_subscriber();
     if (!sub) {
       throw std::runtime_error("get_builtin_subscriber failed");
     }
     // setup publisher listener
-    DDS::DataReader_ptr dr = sub->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC);
+    DDS::DataReader_var dr = sub->lookup_datareader(OpenDDS::DCPS::BUILT_IN_PUBLICATION_TOPIC);
     auto pub_dr = dynamic_cast<DDS::PublicationBuiltinTopicDataDataReader*>(dr);
     if (!pub_dr) {
       throw std::runtime_error("builtin publication datareader is null");


### PR DESCRIPTION
These changes aren't compiler and tested but when I look at the code itself it looks a `_var` should be used to make sure no DDS entities are leaked. Please review!